### PR TITLE
Issue 25

### DIFF
--- a/force-app/main/default/classes/TimelineService.cls
+++ b/force-app/main/default/classes/TimelineService.cls
@@ -17,7 +17,7 @@ public with sharing class TimelineService {
                                         + 'Parent_Object__c =:parentObjectType '
                                         + 'ORDER BY Sequence__c ASC '; //NOPMD
 
-            List<Timeline_Configuration__mdt> listOfTimelineConfigurations = Database.query( queryTimelineConfiguration ); 
+            List<Timeline_Configuration__mdt> listOfTimelineConfigurations = Database.query( queryTimelineConfiguration ); //NOPMD
 
             Map<String, String> mapOfTimelineTypes = new Map<String, String>();
 
@@ -66,7 +66,7 @@ public with sharing class TimelineService {
                                         + 'WHERE Active__c = true AND '
                                         + 'Parent_Object__c =:parentConfigType'; //NOPMD
 
-            List<Timeline_Configuration__mdt> listOfTimelineConfigurations = Database.query( queryTimelineConfiguration );
+            List<Timeline_Configuration__mdt> listOfTimelineConfigurations = Database.query( queryTimelineConfiguration ); //NOPMD
 
             Map<String, TimelineRecord> mapOfTimelineConfigurationRecords = new Map<String, TimelineRecord>();
 
@@ -134,7 +134,7 @@ public with sharing class TimelineService {
                                 + ' FROM ' + parentObjectType 
                                 + ' WHERE Id =:parentObjectId'; //NOPMD
 
-            List<SObject> listOfTimelineRecords = Database.query( queryRecords ); 
+            List<SObject> listOfTimelineRecords = Database.query( queryRecords ); //NOPMD
 
             List<Map<String, String>> listOfTimelineData = new List<Map<String, String>>();
 

--- a/force-app/main/default/classes/TimelineService.cls
+++ b/force-app/main/default/classes/TimelineService.cls
@@ -17,7 +17,7 @@ public with sharing class TimelineService {
                                         + 'Parent_Object__c =:parentObjectType '
                                         + 'ORDER BY Sequence__c ASC ';
 
-            List<Timeline_Configuration__mdt> listOfTimelineConfigurations = Database.query( queryTimelineConfiguration );
+            List<Timeline_Configuration__mdt> listOfTimelineConfigurations = Database.query( queryTimelineConfiguration ); //NOPMD
 
             Map<String, String> mapOfTimelineTypes = new Map<String, String>();
 
@@ -134,52 +134,49 @@ public with sharing class TimelineService {
                                 + ' FROM ' + parentObjectType 
                                 + ' WHERE Id =:parentObjectId';
 
-            List<SObject> listOfTimelineRecords = Database.query( queryRecords );
+            List<SObject> listOfTimelineRecords = Database.query( queryRecords ); //NOPMD
 
             List<Map<String, String>> listOfTimelineData = new List<Map<String, String>>();
 
             for (Sobject each : listOfTimelineRecords) {
-
                 for (String eachObj : mapOfTimelineConfigurationRecords.keyset()) {
-                    //if (childObjects.containsKey(eachObj)) {
-                        if (childObjects.containsKey(eachObj) && each.getSObjects(childObjects.get(eachObj)) != null && each.getSObjects(childObjects.get(eachObj)).size() != 0)
-                            for (Sobject eachCh : (List<SObject>)each.getSObjects(childObjects.get(eachObj))) {
+                    if (childObjects.containsKey(eachObj) && each.getSObjects(childObjects.get(eachObj)) != null && each.getSObjects(childObjects.get(eachObj)).size() != 0)
+                        for (Sobject eachCh : (List<SObject>)each.getSObjects(childObjects.get(eachObj))) {
 
-                                Map<String, String> mapData = new Map<String, String>();
+                            Map<String, String> mapData = new Map<String, String>();
 
-                                TimelineRecord tr = mapOfTimelineConfigurationRecords.get(eachObj );
+                            TimelineRecord tr = mapOfTimelineConfigurationRecords.get(eachObj );
 
-                                String objectLabel  = ((SObject)(Type.forName('Schema.'+ String.valueOf(eachCh.getSobjectType())).newInstance())).getSObjectType().getDescribe().getLabel();
+                            String objectLabel  = ((SObject)(Type.forName('Schema.'+ String.valueOf(eachCh.getSobjectType())).newInstance())).getSObjectType().getDescribe().getLabel();
 
-                                if ( tr != null ) {
-                                    String myId = eachCh.Id;
-                                    Map<String, String> detailValues = getFieldValues(tr.detailField, eachCh);
-                                    Map<String, String> positionValues = getFieldValues(tr.positionDateField, eachCh);
-                                    Map<String, String> fallbackValues = getFieldValues(tr.fallbackTooltipField, eachCh);
-                                    Map<String, String> typeValues = getFieldValues(tr.type, eachCh);
+                            if ( tr != null ) {
+                                String myId = eachCh.Id;
+                                Map<String, String> detailValues = getFieldValues(tr.detailField, eachCh);
+                                Map<String, String> positionValues = getFieldValues(tr.positionDateField, eachCh);
+                                Map<String, String> fallbackValues = getFieldValues(tr.fallbackTooltipField, eachCh);
+                                Map<String, String> typeValues = getFieldValues(tr.type, eachCh);
 
-                                    if ( tr.objectName == 'ContentDocumentLink') {
-                                        myId = String.valueOf(eachCh.get('ContentDocumentId'));
-                                    }
-
-                                    mapData.put('objectId', myId);
-                                    mapData.put('parentObject', parentObjectType);
-                                    mapData.put('detailField', detailValues.get('value'));
-                                    mapData.put('detailFieldLabel', detailValues.get('label'));
-                                    mapData.put('positionDateField', tr.positionDateField);
-                                    mapData.put('positionDateValue', positionValues.get('value'));
-                                    mapData.put('objectName', tr.objectName);
-                                    mapData.put('objectLabel', objectLabel);
-                                    mapData.put('fallbackTooltipField', fallbackValues.get('label'));
-                                    mapData.put('fallbackTooltipValue', fallbackValues.get('value'));
-                                    mapData.put('type', typeValues.get('value'));
-                                    mapData.put('icon', tr.icon);
-                                    mapData.put('iconBackground', tr.iconBackground);
-
-                                    listOfTimelineData.add(mapData);
+                                if ( tr.objectName == 'ContentDocumentLink') { //NOPMD
+                                    myId = String.valueOf(eachCh.get('ContentDocumentId'));
                                 }
+
+                                mapData.put('objectId', myId);
+                                mapData.put('parentObject', parentObjectType);
+                                mapData.put('detailField', detailValues.get('value'));
+                                mapData.put('detailFieldLabel', detailValues.get('label'));
+                                mapData.put('positionDateField', tr.positionDateField);
+                                mapData.put('positionDateValue', positionValues.get('value'));
+                                mapData.put('objectName', tr.objectName);
+                                mapData.put('objectLabel', objectLabel);
+                                mapData.put('fallbackTooltipField', fallbackValues.get('label'));
+                                mapData.put('fallbackTooltipValue', fallbackValues.get('value'));
+                                mapData.put('type', typeValues.get('value'));
+                                mapData.put('icon', tr.icon);
+                                mapData.put('iconBackground', tr.iconBackground);
+
+                                listOfTimelineData.add(mapData);
                             }
-                    //}
+                        }
                 }
             }
             return listOfTimelineData;

--- a/force-app/main/default/classes/TimelineService.cls
+++ b/force-app/main/default/classes/TimelineService.cls
@@ -141,8 +141,8 @@ public with sharing class TimelineService {
             for (Sobject each : listOfTimelineRecords) {
 
                 for (String eachObj : mapOfTimelineConfigurationRecords.keyset()) {
-                    if (childObjects.containsKey(eachObj)) {
-                        if (each.getSObjects(childObjects.get(eachObj)) != null && each.getSObjects(childObjects.get(eachObj)).size() != 0)
+                    //if (childObjects.containsKey(eachObj)) {
+                        if (childObjects.containsKey(eachObj) && each.getSObjects(childObjects.get(eachObj)) != null && each.getSObjects(childObjects.get(eachObj)).size() != 0)
                             for (Sobject eachCh : (List<SObject>)each.getSObjects(childObjects.get(eachObj))) {
 
                                 Map<String, String> mapData = new Map<String, String>();
@@ -179,7 +179,7 @@ public with sharing class TimelineService {
                                     listOfTimelineData.add(mapData);
                                 }
                             }
-                    }
+                    //}
                 }
             }
             return listOfTimelineData;
@@ -246,17 +246,14 @@ public with sharing class TimelineService {
 
     private static Boolean isPersonAccount(String recordId)
     {
-System.Debug('@@ startchecking');
         if ( Account.SObjectType.getDescribe().hasSubtypes ) {
             String queryPersonAccount = 'SELECT Id, IsPersonAccount FROM Account Where Id =:recordId';
             SObject acc = Database.query( queryPersonAccount );
 
             if ( acc.get('IsPersonAccount') == true ) {
-System.Debug('@@ think its a person account');
                 return true;
             }
             else {
-System.Debug('@@ not a person account');
                 return false;
             }
         }

--- a/force-app/main/default/classes/TimelineService.cls
+++ b/force-app/main/default/classes/TimelineService.cls
@@ -189,8 +189,6 @@ public with sharing class TimelineService {
 			if (eachRelationship.getChildSObject().getDescribe().isAccessible()
 			        && !eachRelationship.getChildSObject().getDescribe().getLabel().contains('History')
 			        && eachRelationship.getRelationshipName() != null) {
-
-                //Must match the actual relationship Name value not just the object
                 childRelatedObjects.put(String.valueOf(eachRelationship.getChildSObject() + String.valueOf(eachRelationship.getRelationshipName())), String.valueOf(eachRelationship.getRelationshipName()));
 			}
 		}

--- a/force-app/main/default/classes/TimelineService.cls
+++ b/force-app/main/default/classes/TimelineService.cls
@@ -5,6 +5,9 @@ public with sharing class TimelineService {
 
         try {
             String parentObjectType = String.valueOf(Id.valueOf(parentObjectId).getSobjectType());
+            if (parentObjectType == 'Account' && isPersonAccount(parentObjectId)  ) {
+                parentObjectType = 'PersonAccount';
+            }
 
             String queryTimelineConfiguration = 'SELECT Active__c, '
                                             + 'Object_Name__c, '
@@ -41,7 +44,12 @@ public with sharing class TimelineService {
         
         try {
             String parentObjectType = String.valueOf(Id.valueOf(parentObjectId).getSobjectType());
+            String parentConfigType = parentObjectType;
 
+            if (parentObjectType == 'Account' && isPersonAccount(parentObjectId)  ) {
+                parentConfigType = 'PersonAccount';
+            }
+            
             earliestRange = String.ValueOf((Decimal.ValueOf(earliestRange) * 12).intValue());
             latestRange = String.ValueOf((Decimal.ValueOf(latestRange) * 12).intValue());
 
@@ -56,7 +64,7 @@ public with sharing class TimelineService {
                                             + 'Fallback_Tooltip_Field__c '
                                         + 'FROM Timeline_Configuration__mdt '
                                         + 'WHERE Active__c = true AND '
-                                        + 'Parent_Object__c =:parentObjectType';
+                                        + 'Parent_Object__c =:parentConfigType';
 
             List<Timeline_Configuration__mdt> listOfTimelineConfigurations = Database.query( queryTimelineConfiguration );
 
@@ -187,7 +195,7 @@ public with sharing class TimelineService {
         List<Schema.ChildRelationship> objectRelationships = ((SObject)(Type.forName('Schema.'+ Obj).newInstance())).getSObjectType().getDescribe().getChildRelationships();
 		for (Schema.Childrelationship eachRelationship : objectRelationships) {
 			if (eachRelationship.getChildSObject().getDescribe().isAccessible()
-			        && !eachRelationship.getChildSObject().getDescribe().getLabel().contains('History')
+			        && !eachRelationship.getChildSObject().getDescribe().getLabel().contains('Histories')
 			        && eachRelationship.getRelationshipName() != null) {
                 childRelatedObjects.put(String.valueOf(eachRelationship.getChildSObject() + String.valueOf(eachRelationship.getRelationshipName())), String.valueOf(eachRelationship.getRelationshipName()));
 			}
@@ -234,6 +242,26 @@ public with sharing class TimelineService {
         fieldDetails.put('label', fieldLabel);
 
         return fieldDetails;
+    }
+
+    private static Boolean isPersonAccount(String recordId)
+    {
+System.Debug('@@ startchecking');
+        if ( Account.SObjectType.getDescribe().hasSubtypes ) {
+            String queryPersonAccount = 'SELECT Id, IsPersonAccount FROM Account Where Id =:recordId';
+            SObject acc = Database.query( queryPersonAccount );
+
+            if ( acc.get('IsPersonAccount') == true ) {
+System.Debug('@@ think its a person account');
+                return true;
+            }
+            else {
+System.Debug('@@ not a person account');
+                return false;
+            }
+        }
+
+        return false;
     }
 
     private class TimelineRecord {

--- a/force-app/main/default/classes/TimelineService.cls
+++ b/force-app/main/default/classes/TimelineService.cls
@@ -20,8 +20,7 @@ public with sharing class TimelineService {
 
             for ( Timeline_Configuration__mdt timelineType : listOfTimelineConfigurations ) {
                 
-                List<Schema.DescribeSObjectResult> describeSobjects = Schema.describeSObjects(new List<String>{String.valueOf(timelineType.Object_Name__c)});
-                String objectLabel = describeSobjects[0].getLabelPlural();
+                String objectLabel = ((SObject)(Type.forName('Schema.'+ String.valueOf(timelineType.Object_Name__c)).newInstance())).getSObjectType().getDescribe().getLabelPlural();
 
                 if ( timelineType.Object_Name__c == 'ContentDocumentLink') {
                     objectLabel = System.Label.Timeline_Label_Files;
@@ -47,6 +46,7 @@ public with sharing class TimelineService {
             latestRange = String.ValueOf((Decimal.ValueOf(latestRange) * 12).intValue());
 
             String queryTimelineConfiguration = 'SELECT Detail_Field__c, '
+                                            + 'Relationship_Name__c, '
                                             + 'Active__c, '
                                             + 'Icon__c, '
                                             + 'Icon_Background_Colour__c, '
@@ -66,6 +66,7 @@ public with sharing class TimelineService {
 
                 TimelineRecord timelineRecord = new timelineRecord();
                 timelineRecord.active = timelineConfigurationRecord.Active__c;
+                timelineRecord.relationshipName = timelineConfigurationRecord.Relationship_Name__c;
                 timelineRecord.icon = timelineConfigurationRecord.Icon__c;
                 timelineRecord.iconBackground = timelineConfigurationRecord.Icon_Background_Colour__c;
                 timelineRecord.detailField = timelineConfigurationRecord.Detail_Field__c;
@@ -74,11 +75,10 @@ public with sharing class TimelineService {
                 timelineRecord.positionDateField = timelineConfigurationRecord.Position_Date_Field__c;
                 timelineRecord.fallbackTooltipField = timelineConfigurationRecord.Fallback_Tooltip_Field__c;
 
-                mapOfTimelineConfigurationRecords.put(timelineRecord.objectName, timelineRecord);
+                mapOfTimelineConfigurationRecords.put(timelineRecord.objectName + timelineRecord.relationshipName, timelineRecord);
             }
 
-            Map<String, Schema.SObjectType> schemaMap = Schema.getGlobalDescribe();
-            Map<String, String> childObjects = getChildObjects(parentObjectType, schemaMap);
+            Map<String, String> childObjects = getChildObjects(parentObjectType);
 
             String innerQuery = '';
 
@@ -113,7 +113,7 @@ public with sharing class TimelineService {
 
                     innerQuery = innerQuery + 
                                 selectStatement +
-                                + ' FROM ' + childObjects.get(eachObject) 
+                                + ' FROM ' + tcr.relationshipName 
                                 + ' WHERE ' + tcr.positionDateField + '>= LAST_N_MONTHS:' + earliestRange
                                 + ' AND ' + tcr.positionDateField + ' <= NEXT_N_MONTHS:' + latestRange + '),';
                 }
@@ -128,7 +128,7 @@ public with sharing class TimelineService {
 
             List<SObject> listOfTimelineRecords = Database.query( queryRecords );
 
-            List<Sobject> result = new List<Sobject>();
+            List<Map<String, String>> listOfTimelineData = new List<Map<String, String>>();
 
             for (Sobject each : listOfTimelineRecords) {
 
@@ -136,49 +136,42 @@ public with sharing class TimelineService {
                     if (childObjects.containsKey(eachObj)) {
                         if (each.getSObjects(childObjects.get(eachObj)) != null && each.getSObjects(childObjects.get(eachObj)).size() != 0)
                             for (Sobject eachCh : (List<SObject>)each.getSObjects(childObjects.get(eachObj))) {
-                                result.add(eachCh);
+
+                                Map<String, String> mapData = new Map<String, String>();
+
+                                TimelineRecord tr = mapOfTimelineConfigurationRecords.get(eachObj );
+
+                                String objectLabel  = ((SObject)(Type.forName('Schema.'+ String.valueOf(eachCh.getSobjectType())).newInstance())).getSObjectType().getDescribe().getLabel();
+
+                                if ( tr != null ) {
+                                    String myId = eachCh.Id;
+                                    Map<String, String> detailValues = getFieldValues(tr.detailField, eachCh);
+                                    Map<String, String> positionValues = getFieldValues(tr.positionDateField, eachCh);
+                                    Map<String, String> fallbackValues = getFieldValues(tr.fallbackTooltipField, eachCh);
+                                    Map<String, String> typeValues = getFieldValues(tr.type, eachCh);
+
+                                    if ( tr.objectName == 'ContentDocumentLink') {
+                                        myId = String.valueOf(eachCh.get('ContentDocumentId'));
+                                    }
+
+                                    mapData.put('objectId', myId);
+                                    mapData.put('parentObject', parentObjectType);
+                                    mapData.put('detailField', detailValues.get('value'));
+                                    mapData.put('detailFieldLabel', detailValues.get('label'));
+                                    mapData.put('positionDateField', tr.positionDateField);
+                                    mapData.put('positionDateValue', positionValues.get('value'));
+                                    mapData.put('objectName', tr.objectName);
+                                    mapData.put('objectLabel', objectLabel);
+                                    mapData.put('fallbackTooltipField', fallbackValues.get('label'));
+                                    mapData.put('fallbackTooltipValue', fallbackValues.get('value'));
+                                    mapData.put('type', typeValues.get('value'));
+                                    mapData.put('icon', tr.icon);
+                                    mapData.put('iconBackground', tr.iconBackground);
+
+                                    listOfTimelineData.add(mapData);
+                                }
                             }
                     }
-                }
-            }
-
-            List<Map<String, String>> listOfTimelineData = new List<Map<String, String>>();
-            
-            for (SObject records : result) {
-
-                Map<String, String> mapData = new Map<String, String>();
-
-                TimelineRecord tr = mapOfTimelineConfigurationRecords.get(String.valueOf(records.getSobjectType()));
-
-                List<Schema.DescribeSObjectResult> describeSobjects = Schema.describeSObjects(new List<String>{String.valueOf(records.getSobjectType())});
-
-                if ( tr != null ) {
-                    String myId = records.Id;
-                    //String positionDate = String.valueOf(records.get(tr.positionDateField));
-                    Map<String, String> detailValues = getFieldValues(tr.detailField, records);
-                    Map<String, String> positionValues = getFieldValues(tr.positionDateField, records);
-                    Map<String, String> fallbackValues = getFieldValues(tr.fallbackTooltipField, records);
-                    Map<String, String> typeValues = getFieldValues(tr.type, records);
-
-                    if ( tr.objectName == 'ContentDocumentLink') {
-                        myId = String.valueOf(records.get('ContentDocumentId'));
-                    }
-
-                    mapData.put('objectId', myId);
-                    mapData.put('parentObject', parentObjectType);
-                    mapData.put('detailField', detailValues.get('value'));
-                    mapData.put('detailFieldLabel', detailValues.get('label'));
-                    mapData.put('positionDateField', tr.positionDateField);
-                    mapData.put('positionDateValue', positionValues.get('value'));
-                    mapData.put('objectName', tr.objectName);
-                    mapData.put('objectLabel', describeSobjects[0].getLabel());
-                    mapData.put('fallbackTooltipField', fallbackValues.get('label'));
-                    mapData.put('fallbackTooltipValue', fallbackValues.get('value'));
-                    mapData.put('type', typeValues.get('value'));
-                    mapData.put('icon', tr.icon);
-                    mapData.put('iconBackground', tr.iconBackground);
-
-                    listOfTimelineData.add(mapData);
                 }
             }
             return listOfTimelineData;
@@ -188,14 +181,17 @@ public with sharing class TimelineService {
         }
     }
 
-    private static Map<String, String> getChildObjects(String Obj, Map<String, Schema.SObjectType> schemaMap) {
+    private static Map<String, String> getChildObjects(String Obj) {
 		Map<String, String> childRelatedObjects = new Map<String, String>();
-		List<Schema.ChildRelationship> objectRelationships = schemaMap.get(Obj).getDescribe().getChildRelationships();
+       
+        List<Schema.ChildRelationship> objectRelationships = ((SObject)(Type.forName('Schema.'+ Obj).newInstance())).getSObjectType().getDescribe().getChildRelationships();
 		for (Schema.Childrelationship eachRelationship : objectRelationships) {
 			if (eachRelationship.getChildSObject().getDescribe().isAccessible()
 			        && !eachRelationship.getChildSObject().getDescribe().getLabel().contains('History')
 			        && eachRelationship.getRelationshipName() != null) {
-				childRelatedObjects.put(String.valueOf(eachRelationship.getChildSObject()), String.valueOf(eachRelationship.getRelationshipName()));
+
+                //Must match the actual relationship Name value not just the object
+                childRelatedObjects.put(String.valueOf(eachRelationship.getChildSObject() + String.valueOf(eachRelationship.getRelationshipName())), String.valueOf(eachRelationship.getRelationshipName()));
 			}
 		}
 		return childRelatedObjects;
@@ -207,9 +203,7 @@ public with sharing class TimelineService {
 
         String fieldValue = '';
         String fieldLabel = '';
-
-        List<Schema.DescribeSObjectResult> describeSobjects = Schema.describeSObjects(new List<String>{String.valueOf(records.getSobjectType())});
-
+       
         if ( field == null || field == '' ) {
             fieldDetails.put('value' ,'');
             fieldDetails.put('label', '');
@@ -224,13 +218,14 @@ public with sharing class TimelineService {
 
             fieldValue = String.valueOf(records.getSobject(splitObject).get(splitField));
 
-            List<Schema.DescribeSObjectResult> describeParentSobjects = Schema.describeSObjects(new List<String>{String.valueOf(splitObject)});
-
-            fieldLabel = String.valueOf( describeParentSobjects[0].fields.getMap().get(splitField).getDescribe().getLabel() );
+            Schema.DescribeSObjectResult describeParentSobjects = ((SObject)(Type.forName('Schema.'+ String.valueOf(splitObject)).newInstance())).getSObjectType().getDescribe();
+            fieldLabel = String.valueOf( describeParentSobjects.fields.getMap().get(splitField).getDescribe().getLabel() );
         }
         else {
+            Schema.DescribeSObjectResult describeSobjects = ((SObject)(Type.forName('Schema.'+ String.valueOf(records.getSobjectType())).newInstance())).getSObjectType().getDescribe();
+
             fieldValue = String.valueOf(records.get(field));
-            fieldLabel = String.valueOf( describeSobjects[0].fields.getMap().get(field).getDescribe().getLabel() );
+            fieldLabel = String.valueOf( describeSobjects.fields.getMap().get(field).getDescribe().getLabel() );
         }
 
         if (fieldValue != null && fieldValue.length() > 255) {
@@ -245,6 +240,7 @@ public with sharing class TimelineService {
 
     private class TimelineRecord {
         @AuraEnabled public Boolean active;
+        @AuraEnabled public String relationshipName;
         @AuraEnabled public String parentObject;
         @AuraEnabled public String detailField;
         @AuraEnabled public String detailFieldLabel;

--- a/force-app/main/default/classes/TimelineService.cls
+++ b/force-app/main/default/classes/TimelineService.cls
@@ -15,9 +15,9 @@ public with sharing class TimelineService {
                                         + 'FROM Timeline_Configuration__mdt '
                                         + 'WHERE Active__c = true AND '
                                         + 'Parent_Object__c =:parentObjectType '
-                                        + 'ORDER BY Sequence__c ASC ';
+                                        + 'ORDER BY Sequence__c ASC '; //NOPMD
 
-            List<Timeline_Configuration__mdt> listOfTimelineConfigurations = Database.query( queryTimelineConfiguration ); //NOPMD
+            List<Timeline_Configuration__mdt> listOfTimelineConfigurations = Database.query( queryTimelineConfiguration ); 
 
             Map<String, String> mapOfTimelineTypes = new Map<String, String>();
 
@@ -64,7 +64,7 @@ public with sharing class TimelineService {
                                             + 'Fallback_Tooltip_Field__c '
                                         + 'FROM Timeline_Configuration__mdt '
                                         + 'WHERE Active__c = true AND '
-                                        + 'Parent_Object__c =:parentConfigType';
+                                        + 'Parent_Object__c =:parentConfigType'; //NOPMD
 
             List<Timeline_Configuration__mdt> listOfTimelineConfigurations = Database.query( queryTimelineConfiguration );
 
@@ -132,9 +132,9 @@ public with sharing class TimelineService {
             String queryRecords = 'SELECT Id, ' 
                                     + innerQuery 
                                 + ' FROM ' + parentObjectType 
-                                + ' WHERE Id =:parentObjectId';
+                                + ' WHERE Id =:parentObjectId'; //NOPMD
 
-            List<SObject> listOfTimelineRecords = Database.query( queryRecords ); //NOPMD
+            List<SObject> listOfTimelineRecords = Database.query( queryRecords ); 
 
             List<Map<String, String>> listOfTimelineData = new List<Map<String, String>>();
 
@@ -258,7 +258,7 @@ public with sharing class TimelineService {
         return false;
     }
 
-    private class TimelineRecord {
+    private class TimelineRecord { //NOPMD
         @AuraEnabled public Boolean active;
         @AuraEnabled public String relationshipName;
         @AuraEnabled public String parentObject;

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Account_Cases.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Account_Cases.md-meta.xml
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">TBD</value>
+        <value xsi:type="xsd:string">Cases</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Account_Cases.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Account_Cases.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">CreatedDate</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">50.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Account_Contacts.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Account_Contacts.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">CreatedDate</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">40.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Account_Contacts.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Account_Contacts.md-meta.xml
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">TBD</value>
+        <value xsi:type="xsd:string">Contacts</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Account_Events.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Account_Events.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">StartDateTime</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">20.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Account_Events.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Account_Events.md-meta.xml
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">TBD</value>
+        <value xsi:type="xsd:string">Events</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Account_Files.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Account_Files.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">SystemModstamp</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">30.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Account_Files.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Account_Files.md-meta.xml
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">TBD</value>
+        <value xsi:type="xsd:string">ContentDocumentLinks</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Account_Opportunities.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Account_Opportunities.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">CreatedDate</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">60.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Account_Tasks.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Account_Tasks.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">ActivityDate</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">10.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Account_Tasks.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Account_Tasks.md-meta.xml
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">TBD</value>
+        <value xsi:type="xsd:string">Tasks</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Case_CaseComments.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Case_CaseComments.md-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Account_Opportunities</label>
+    <label>Case_CaseComments</label>
     <protected>true</protected>
     <values>
         <field>Active__c</field>
@@ -12,27 +12,27 @@
     </values>
     <values>
         <field>Detail_Field__c</field>
-        <value xsi:type="xsd:string">Name</value>
+        <value xsi:type="xsd:string">CommentBody</value>
     </values>
     <values>
         <field>Fallback_Tooltip_Field__c</field>
-        <value xsi:nil="true"/>
+        <value xsi:type="xsd:string">IsPublished</value>
     </values>
     <values>
         <field>Icon_Background_Colour__c</field>
-        <value xsi:type="xsd:string">#fcb95b</value>
+        <value xsi:type="xsd:string">#f2cf5b</value>
     </values>
     <values>
         <field>Icon__c</field>
-        <value xsi:type="xsd:string">/img/icon/t4v35/standard/opportunity.svg</value>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/case_comment.svg</value>
     </values>
     <values>
         <field>Object_Name__c</field>
-        <value xsi:type="xsd:string">Opportunity</value>
+        <value xsi:type="xsd:string">CaseComment</value>
     </values>
     <values>
         <field>Parent_Object__c</field>
-        <value xsi:type="xsd:string">Account</value>
+        <value xsi:type="xsd:string">Case</value>
     </values>
     <values>
         <field>Position_Date_Field__c</field>
@@ -40,11 +40,11 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">Opportunities</value>
+        <value xsi:type="xsd:string">CaseComments</value>
     </values>
     <values>
         <field>Sequence__c</field>
-        <value xsi:type="xsd:double">60.0</value>
+        <value xsi:type="xsd:double">50.0</value>
     </values>
     <values>
         <field>Type_Field__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Case_Events.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Case_Events.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">StartDateTime</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">20.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Case_Events.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Case_Events.md-meta.xml
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">TBD</value>
+        <value xsi:type="xsd:string">Events</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Case_Files.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Case_Files.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">SystemModstamp</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">30.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Case_Files.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Case_Files.md-meta.xml
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">TBD</value>
+        <value xsi:type="xsd:string">ContentDocumentLinks</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Case_Tasks.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Case_Tasks.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">ActivityDate</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">10.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Case_Tasks.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Case_Tasks.md-meta.xml
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">TBD</value>
+        <value xsi:type="xsd:string">Tasks</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Case_WorkOrders.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Case_WorkOrders.md-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Account_Opportunities</label>
+    <label>Case_WorkOrders</label>
     <protected>true</protected>
     <values>
         <field>Active__c</field>
@@ -12,7 +12,7 @@
     </values>
     <values>
         <field>Detail_Field__c</field>
-        <value xsi:type="xsd:string">Name</value>
+        <value xsi:type="xsd:string">Description</value>
     </values>
     <values>
         <field>Fallback_Tooltip_Field__c</field>
@@ -20,19 +20,19 @@
     </values>
     <values>
         <field>Icon_Background_Colour__c</field>
-        <value xsi:type="xsd:string">#fcb95b</value>
+        <value xsi:type="xsd:string">#50e3c2</value>
     </values>
     <values>
         <field>Icon__c</field>
-        <value xsi:type="xsd:string">/img/icon/t4v35/standard/opportunity.svg</value>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/work_order.svg</value>
     </values>
     <values>
         <field>Object_Name__c</field>
-        <value xsi:type="xsd:string">Opportunity</value>
+        <value xsi:type="xsd:string">WorkOrder</value>
     </values>
     <values>
         <field>Parent_Object__c</field>
-        <value xsi:type="xsd:string">Account</value>
+        <value xsi:type="xsd:string">Case</value>
     </values>
     <values>
         <field>Position_Date_Field__c</field>
@@ -40,11 +40,11 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">Opportunities</value>
+        <value xsi:type="xsd:string">WorkOrders</value>
     </values>
     <values>
         <field>Sequence__c</field>
-        <value xsi:type="xsd:double">60.0</value>
+        <value xsi:type="xsd:double">70.0</value>
     </values>
     <values>
         <field>Type_Field__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Contact_CampaignMembers.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Contact_CampaignMembers.md-meta.xml
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">TBD</value>
+        <value xsi:type="xsd:string">CampaignMembers</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Contact_CampaignMembers.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Contact_CampaignMembers.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">CreatedDate</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">60.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Cases.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Cases.md-meta.xml
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">TBD</value>
+        <value xsi:type="xsd:string">Cases</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Cases.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Cases.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">CreatedDate</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">40.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Events.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Events.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">StartDateTime</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">20.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Events.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Events.md-meta.xml
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">TBD</value>
+        <value xsi:type="xsd:string">Events</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Files.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Files.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">SystemModstamp</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">30.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Files.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Files.md-meta.xml
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">TBD</value>
+        <value xsi:type="xsd:string">ContentDocumentLinks</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Opportunities.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Opportunities.md-meta.xml
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">TBD</value>
+        <value xsi:type="xsd:string">Opportunities</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Opportunities.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Opportunities.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">CreatedDate</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">50.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Tasks.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Tasks.md-meta.xml
@@ -39,6 +39,10 @@
         <value xsi:type="xsd:string">ActivityDate</value>
     </values>
     <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TBD</value>
+    </values>
+    <values>
         <field>Sequence__c</field>
         <value xsi:type="xsd:double">10.0</value>
     </values>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Tasks.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Contact_Tasks.md-meta.xml
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">TBD</value>
+        <value xsi:type="xsd:string">Tasks</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.PersonAccount_Cases.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.PersonAccount_Cases.md-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Account_Opportunities</label>
+    <label>PersonAccount_Cases</label>
     <protected>true</protected>
     <values>
         <field>Active__c</field>
@@ -12,7 +12,7 @@
     </values>
     <values>
         <field>Detail_Field__c</field>
-        <value xsi:type="xsd:string">Name</value>
+        <value xsi:type="xsd:string">Subject</value>
     </values>
     <values>
         <field>Fallback_Tooltip_Field__c</field>
@@ -20,19 +20,19 @@
     </values>
     <values>
         <field>Icon_Background_Colour__c</field>
-        <value xsi:type="xsd:string">#fcb95b</value>
+        <value xsi:type="xsd:string">#f2cf5b</value>
     </values>
     <values>
         <field>Icon__c</field>
-        <value xsi:type="xsd:string">/img/icon/t4v35/standard/opportunity.svg</value>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/case.svg</value>
     </values>
     <values>
         <field>Object_Name__c</field>
-        <value xsi:type="xsd:string">Opportunity</value>
+        <value xsi:type="xsd:string">Case</value>
     </values>
     <values>
         <field>Parent_Object__c</field>
-        <value xsi:type="xsd:string">Account</value>
+        <value xsi:type="xsd:string">PersonAccount</value>
     </values>
     <values>
         <field>Position_Date_Field__c</field>
@@ -40,11 +40,11 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">Opportunities</value>
+        <value xsi:type="xsd:string">PersonCases</value>
     </values>
     <values>
         <field>Sequence__c</field>
-        <value xsi:type="xsd:double">60.0</value>
+        <value xsi:type="xsd:double">50.0</value>
     </values>
     <values>
         <field>Type_Field__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.PersonAccount_Contacts.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.PersonAccount_Contacts.md-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Account_Opportunities</label>
+    <label>PersonAccount_Contacts</label>
     <protected>true</protected>
     <values>
         <field>Active__c</field>
@@ -20,19 +20,19 @@
     </values>
     <values>
         <field>Icon_Background_Colour__c</field>
-        <value xsi:type="xsd:string">#fcb95b</value>
+        <value xsi:type="xsd:string">#A094ED</value>
     </values>
     <values>
         <field>Icon__c</field>
-        <value xsi:type="xsd:string">/img/icon/t4v35/standard/opportunity.svg</value>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/contact_120.png</value>
     </values>
     <values>
         <field>Object_Name__c</field>
-        <value xsi:type="xsd:string">Opportunity</value>
+        <value xsi:type="xsd:string">Contact</value>
     </values>
     <values>
         <field>Parent_Object__c</field>
-        <value xsi:type="xsd:string">Account</value>
+        <value xsi:type="xsd:string">PersonAccount</value>
     </values>
     <values>
         <field>Position_Date_Field__c</field>
@@ -40,11 +40,11 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">Opportunities</value>
+        <value xsi:type="xsd:string">PersonContacts</value>
     </values>
     <values>
         <field>Sequence__c</field>
-        <value xsi:type="xsd:double">60.0</value>
+        <value xsi:type="xsd:double">40.0</value>
     </values>
     <values>
         <field>Type_Field__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.PersonAccount_Events.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.PersonAccount_Events.md-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Account_Opportunities</label>
+    <label>PersonAccount_Events</label>
     <protected>true</protected>
     <values>
         <field>Active__c</field>
@@ -12,39 +12,39 @@
     </values>
     <values>
         <field>Detail_Field__c</field>
-        <value xsi:type="xsd:string">Name</value>
+        <value xsi:type="xsd:string">Subject</value>
     </values>
     <values>
         <field>Fallback_Tooltip_Field__c</field>
-        <value xsi:nil="true"/>
+        <value xsi:type="xsd:string">Description</value>
     </values>
     <values>
         <field>Icon_Background_Colour__c</field>
-        <value xsi:type="xsd:string">#fcb95b</value>
+        <value xsi:type="xsd:string">#eb7092</value>
     </values>
     <values>
         <field>Icon__c</field>
-        <value xsi:type="xsd:string">/img/icon/t4v35/standard/opportunity.svg</value>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/event.svg</value>
     </values>
     <values>
         <field>Object_Name__c</field>
-        <value xsi:type="xsd:string">Opportunity</value>
+        <value xsi:type="xsd:string">Event</value>
     </values>
     <values>
         <field>Parent_Object__c</field>
-        <value xsi:type="xsd:string">Account</value>
+        <value xsi:type="xsd:string">PersonAccount</value>
     </values>
     <values>
         <field>Position_Date_Field__c</field>
-        <value xsi:type="xsd:string">CreatedDate</value>
+        <value xsi:type="xsd:string">StartDateTime</value>
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">Opportunities</value>
+        <value xsi:type="xsd:string">PersonEvents</value>
     </values>
     <values>
         <field>Sequence__c</field>
-        <value xsi:type="xsd:double">60.0</value>
+        <value xsi:type="xsd:double">20.0</value>
     </values>
     <values>
         <field>Type_Field__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.PersonAccount_Files.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.PersonAccount_Files.md-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Account_Opportunities</label>
+    <label>PersonAccount_Files</label>
     <protected>true</protected>
     <values>
         <field>Active__c</field>
@@ -12,42 +12,42 @@
     </values>
     <values>
         <field>Detail_Field__c</field>
-        <value xsi:type="xsd:string">Name</value>
+        <value xsi:type="xsd:string">ContentDocument.Title</value>
     </values>
     <values>
         <field>Fallback_Tooltip_Field__c</field>
-        <value xsi:nil="true"/>
+        <value xsi:type="xsd:string">ContentDocument.FileExtension</value>
     </values>
     <values>
         <field>Icon_Background_Colour__c</field>
-        <value xsi:type="xsd:string">#fcb95b</value>
+        <value xsi:type="xsd:string">#b19f7e</value>
     </values>
     <values>
         <field>Icon__c</field>
-        <value xsi:type="xsd:string">/img/icon/t4v35/standard/opportunity.svg</value>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/document.svg</value>
     </values>
     <values>
         <field>Object_Name__c</field>
-        <value xsi:type="xsd:string">Opportunity</value>
+        <value xsi:type="xsd:string">ContentDocumentLink</value>
     </values>
     <values>
         <field>Parent_Object__c</field>
-        <value xsi:type="xsd:string">Account</value>
+        <value xsi:type="xsd:string">PersonAccount</value>
     </values>
     <values>
         <field>Position_Date_Field__c</field>
-        <value xsi:type="xsd:string">CreatedDate</value>
+        <value xsi:type="xsd:string">SystemModstamp</value>
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">Opportunities</value>
+        <value xsi:type="xsd:string">ContentDocumentLinks</value>
     </values>
     <values>
         <field>Sequence__c</field>
-        <value xsi:type="xsd:double">60.0</value>
+        <value xsi:type="xsd:double">30.0</value>
     </values>
     <values>
         <field>Type_Field__c</field>
-        <value xsi:nil="true"/>
+        <value xsi:type="xsd:string">ContentDocument.FileType</value>
     </values>
 </CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.PersonAccount_Opportunities.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.PersonAccount_Opportunities.md-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Account_Opportunities</label>
+    <label>PersonAccount_Opportunities</label>
     <protected>true</protected>
     <values>
         <field>Active__c</field>
@@ -32,7 +32,7 @@
     </values>
     <values>
         <field>Parent_Object__c</field>
-        <value xsi:type="xsd:string">Account</value>
+        <value xsi:type="xsd:string">PersonAccount</value>
     </values>
     <values>
         <field>Position_Date_Field__c</field>
@@ -40,7 +40,7 @@
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">Opportunities</value>
+        <value xsi:type="xsd:string">PersonOpportunities</value>
     </values>
     <values>
         <field>Sequence__c</field>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.PersonAccount_Tasks.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.PersonAccount_Tasks.md-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>Account_Opportunities</label>
+    <label>PersonAccount_Tasks</label>
     <protected>true</protected>
     <values>
         <field>Active__c</field>
@@ -12,42 +12,42 @@
     </values>
     <values>
         <field>Detail_Field__c</field>
-        <value xsi:type="xsd:string">Name</value>
+        <value xsi:type="xsd:string">Subject</value>
     </values>
     <values>
         <field>Fallback_Tooltip_Field__c</field>
-        <value xsi:nil="true"/>
+        <value xsi:type="xsd:string">Description</value>
     </values>
     <values>
         <field>Icon_Background_Colour__c</field>
-        <value xsi:type="xsd:string">#fcb95b</value>
+        <value xsi:type="xsd:string">#4ac076</value>
     </values>
     <values>
         <field>Icon__c</field>
-        <value xsi:type="xsd:string">/img/icon/t4v35/standard/opportunity.svg</value>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/task.svg</value>
     </values>
     <values>
         <field>Object_Name__c</field>
-        <value xsi:type="xsd:string">Opportunity</value>
+        <value xsi:type="xsd:string">Task</value>
     </values>
     <values>
         <field>Parent_Object__c</field>
-        <value xsi:type="xsd:string">Account</value>
+        <value xsi:type="xsd:string">PersonAccount</value>
     </values>
     <values>
         <field>Position_Date_Field__c</field>
-        <value xsi:type="xsd:string">CreatedDate</value>
+        <value xsi:type="xsd:string">ActivityDate</value>
     </values>
     <values>
         <field>Relationship_Name__c</field>
-        <value xsi:type="xsd:string">Opportunities</value>
+        <value xsi:type="xsd:string">PersonTasks</value>
     </values>
     <values>
         <field>Sequence__c</field>
-        <value xsi:type="xsd:double">60.0</value>
+        <value xsi:type="xsd:double">10.0</value>
     </values>
     <values>
         <field>Type_Field__c</field>
-        <value xsi:nil="true"/>
+        <value xsi:type="xsd:string">TaskSubtype</value>
     </values>
 </CustomMetadata>

--- a/force-app/main/default/lwc/timeline/timeline.js
+++ b/force-app/main/default/lwc/timeline/timeline.js
@@ -360,7 +360,7 @@ export default class timeline extends NavigationMixin(LightningElement) {
        
         timelineCanvas.filter = function(d) {
 
-            if ( me.filterValues.includes(d.objectName)) {
+            if (me.filterValues == undefined || me.filterValues == '' || me.filterValues.includes(d.objectName)) {
                 return true;
             }
         
@@ -645,10 +645,9 @@ export default class timeline extends NavigationMixin(LightningElement) {
         };
 
         timelineMap.filter = function(d) {
-            if ( me.filterValues.includes(d.objectName)) {
+            if (me.filterValues == undefined || me.filterValues == '' || me.filterValues.includes(d.objectName)) {
                 return true;
             }
-    
             return false;
         };
 
@@ -811,19 +810,6 @@ export default class timeline extends NavigationMixin(LightningElement) {
                 me.localisedZoomStartDate = dateTimeFormat.format(moment(timelineMap.x.invert(selection[0])));
                 me.localisedZoomEndDate = dateTimeFormat.format(moment(timelineMap.x.invert(selection[1])));
                
-            }
-            else {
- 
-                dommy.push(timelineMap.x.invert(me.zoomStartDate));
-                dommy.push(timelineMap.x.invert(me.zoomEndDate));
-
-                d3timeline.redraw(dommy);
-                timelineAxis.redraw();
-                timelineAxisLabel.redraw();
-
-                handle.attr("transform", function() { 
-                    return "translate(" + (timelineMap.x.invert(me.zoomStartDate) - 2) + ", " + 0  + ") scale(0.05)"; 
-                });
             }
         }
 

--- a/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Relationship_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Relationship_Name__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Relationship_Name__c</fullName>
+    <description>The API name corresponding to the relationship between the objects.</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>The API name corresponding to the relationship between the objects.</inlineHelpText>
+    <label>Relationship Name</label>
+    <length>255</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Relationship_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Relationship_Name__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Relationship_Name__c</fullName>
     <description>The API name corresponding to the relationship between the objects.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>The API name corresponding to the relationship between the objects.</inlineHelpText>
     <label>Relationship Name</label>
     <length>255</length>


### PR DESCRIPTION
Fixes for 
Multiple relationships to the same object. Custom metadata type now supports multiple records to the same object for different relationship types.
Race condition for the filter values where render operation happens prior to async query