### PR TITLE
Vertical scrollbar fix

### DIFF
--- a/force-app/main/default/lwc/timeline/timeline.js
+++ b/force-app/main/default/lwc/timeline/timeline.js
@@ -401,7 +401,7 @@ export default class timeline extends NavigationMixin(LightningElement) {
             const svgHeight = Math.max(timelineCanvas.y(swimlanes.length), timelineHeight);
             timelineCanvas.height = timelineHeight;
 
-            timelineCanvas.attr('height', svgHeight);
+            timelineCanvas.attr('height', svgHeight - 1);
             timelineCanvas.SVGHeight = svgHeight;
 
             timelineCanvas.data = timelineCanvas.selectAll('[class~=timeline-canvas-record]')


### PR DESCRIPTION
Adjusted the SVG height to ensure that a scrollbar doesn't appear by default. This was causing the vertical scrolling down a page to be interrupted. Closes #22 