### PR TITLE
Disable refresh when filter is active

### DIFF
--- a/force-app/main/default/lwc/timeline/timeline.html
+++ b/force-app/main/default/lwc/timeline/timeline.html
@@ -28,8 +28,8 @@
                     </div>
                     <div class="slds-form-element">
                         <lightning-button-group>
-                            <lightning-button-icon class="forceRefreshButton rotate" icon-name="utility:refresh"  alternative-text="Refresh" onclick={processTimeline}></lightning-button-icon>
-                            <lightning-button-icon-stateful icon-name="utility:filterList" selected={isFilter} onclick={toggleFilter} alternative-text="Refresh"></lightning-button-icon-stateful>
+                            <lightning-button-icon class="timeline-refresh" icon-name="utility:refresh"  alternative-text="Refresh" onclick={processTimeline}></lightning-button-icon>
+                            <lightning-button-icon-stateful icon-name="utility:filterList" selected={isFilter} onclick={toggleFilter} alternative-text="Filter"></lightning-button-icon-stateful>
                         </lightning-button-group>
                     </div>
                 </div>

--- a/force-app/main/default/lwc/timeline/timeline.js
+++ b/force-app/main/default/lwc/timeline/timeline.js
@@ -914,12 +914,15 @@ export default class timeline extends NavigationMixin(LightningElement) {
     toggleFilter() {
         const filterPopover = this.template.querySelector("div.timeline-filter");
         const filterClasses = String(filterPopover.classList);
+        const refreshButton = this.template.querySelector("lightning-button-icon.timeline-refresh");
 
         if ( filterClasses.includes('slds-is-open') ) {
+            refreshButton.disabled = false;
             filterPopover.classList.remove('slds-is-open');
             this.isFilter = false;
         }
         else {
+            refreshButton.disabled = true;
             filterPopover.classList.add('slds-is-open');
             this.isFilter = true;
         }


### PR DESCRIPTION
When filter panel is active the refresh button becomes disabled forcing the use of the Apply or Cancel buttons in the filter panel