### PR TITLE
Check detail field for null

### DIFF
--- a/force-app/main/default/classes/TimelineService.cls
+++ b/force-app/main/default/classes/TimelineService.cls
@@ -192,7 +192,14 @@ public with sharing class TimelineService {
 
                                 mapData.put('objectId', myId);
                                 mapData.put('parentObject', parentObjectType);
-                                mapData.put('detailField', detailValues.get('value'));
+
+                                if ( detailValues.get('value') == '' || detailValues.get('value') == null ) { //NOPMD
+                                    mapData.put('detailField', '[' + detailValues.get('label') +']');
+                                }
+                                else {
+                                    mapData.put('detailField', detailValues.get('value'));
+                                }
+                                
                                 mapData.put('detailFieldLabel', detailValues.get('label'));
                                 mapData.put('positionDateField', tr.positionDateField);
                                 mapData.put('positionDateValue', positionValues.get('value'));


### PR DESCRIPTION
Check to see if the field value for the detail plot is null. If it is use the label as a replacement so that something is plotted on the timeline and so that it doesn't error