### PR TITLE
Add plot limit for map

### DIFF
--- a/force-app/main/default/lwc/timeline/timeline.js
+++ b/force-app/main/default/lwc/timeline/timeline.js
@@ -700,6 +700,13 @@ export default class timeline extends NavigationMixin(LightningElement) {
                 swimlanes[swimlane] = entry.endTime;
             });
 
+            data = data.filter(function(d) {
+                if ( d.swimlane < 8 ) {
+                    return true;
+                }
+                return false;
+            });
+
             timelineMap.width = timelineMap.x.range()[1];
             timelineMapSVG.attr('width', timelineMap.width);
 


### PR DESCRIPTION
When supporting large volumes we now limit the number of records plotted on the timeline map since it isn't supposed to scroll and the max number of swimlanes is 9 we don't bother plotting any records further.

This reduces the number of svgs plotted when not needed