### PR TITLE
Support for multiple objects

### DIFF
--- a/force-app/main/default/classes/TimelineParentPicklist.cls
+++ b/force-app/main/default/classes/TimelineParentPicklist.cls
@@ -14,7 +14,7 @@ global with sharing class TimelineParentPicklist extends VisualEditor.DynamicPic
     }
 
     global override VisualEditor.DataRow getDefaultValue() {
-        if ( this.context.entityName != null ) {
+        if (this.context.entityName != null) {
             String objectLabel = ((SObject) (Type.forName('Schema.' + String.valueOf(this.context.entityName))
                     .newInstance()))
                 .getSObjectType()
@@ -35,8 +35,10 @@ global with sharing class TimelineParentPicklist extends VisualEditor.DynamicPic
         VisualEditor.DynamicPickListRows myValues = new VisualEditor.DynamicPickListRows();
         myValues.addRow(getDefaultValue());
 
-        if ( this.context.entityName != null && this.context.pageType != 'CommRecordPage') {
-            Schema.DescribeSObjectResult describeSobjects = ((SObject) (Type.forName('Schema.' + this.context.entityName)
+        if (this.context.entityName != null && this.context.pageType != 'CommRecordPage') {
+            Schema.DescribeSObjectResult describeSobjects = ((SObject) (Type.forName(
+                        'Schema.' + this.context.entityName
+                    )
                     .newInstance()))
                 .getSObjectType()
                 .getDescribe();
@@ -49,19 +51,13 @@ global with sharing class TimelineParentPicklist extends VisualEditor.DynamicPic
                 if (
                     currentField.isAccessible() &&
                     currentField.isNamePointing() == false &&
-                    currentField.getLabel() != 'Master Record ID' &&
-                    (String.valueOf(currentField.getReferenceTo()) == '(Lead)' ||
-                    String.valueOf(currentField.getReferenceTo()) == '(Contact)' ||
-                    String.valueOf(currentField.getReferenceTo()) == '(Account)' ||
-                    String.valueOf(currentField.getReferenceTo()) == '(Opportunity)' ||
-                    String.valueOf(currentField.getReferenceTo()) == '(Case)')
+                    currentField.getLabel() != 'Master Record ID'
                 ) {
                     myValues.addRow(new VisualEditor.DataRow(currentField.getLabel(), field));
                 }
             }
             return myValues;
-        }
-        else {
+        } else {
             return myValues;
         }
     }

--- a/force-app/main/default/classes/TimelineParentPicklist.cls
+++ b/force-app/main/default/classes/TimelineParentPicklist.cls
@@ -41,17 +41,21 @@ global with sharing class TimelineParentPicklist extends VisualEditor.DynamicPic
                     )
                     .newInstance()))
                 .getSObjectType()
-                .getDescribe();
+                .getDescribe(SObjectDescribeOptions.DEFERRED);
 
             Map<String, Schema.SObjectField> myFields = describeSobjects.fields.getMap();
 
             for (String field : myFields.keySet()) {
                 Schema.DescribeFieldResult currentField = myFields.get(field).getDescribe();
-
+                System.Debug('@@@ - ' + currentField.getReferenceTo());
                 if (
                     currentField.isAccessible() &&
                     currentField.isNamePointing() == false &&
-                    currentField.getLabel() != 'Master Record ID'
+                    currentField.getLabel() != 'Master Record ID' &&
+                    (String.valueOf(currentField.getReferenceTo()) != '' &&
+                    String.valueOf(currentField.getReferenceTo()) != null && 
+                    String.valueOf(currentField.getReferenceTo()) != '()' && 
+                    String.valueOf(currentField.getReferenceTo()) != '(User)')
                 ) {
                     myValues.addRow(new VisualEditor.DataRow(currentField.getLabel(), field));
                 }

--- a/force-app/main/default/classes/TimelineParentPicklist.cls-meta.xml
+++ b/force-app/main/default/classes/TimelineParentPicklist.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>50.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TimelineParentPicklist_Test.cls
+++ b/force-app/main/default/classes/TimelineParentPicklist_Test.cls
@@ -10,11 +10,10 @@ private with sharing class TimelineParentPicklist_Test {
         VisualEditor.DesignTimePageContext context = new VisualEditor.DesignTimePageContext();
         context.entityName = 'Contact';
 
-        String objectLabel = ((SObject) (Type.forName('Schema.Contact')
-                    .newInstance()))
-                .getSObjectType()
-                .getDescribe()
-                .getLabel();
+        String objectLabel = ((SObject) (Type.forName('Schema.Contact').newInstance()))
+            .getSObjectType()
+            .getDescribe()
+            .getLabel();
 
         TimelineParentPicklist timeline = new TimelineParentPicklist(context);
 

--- a/force-app/main/default/classes/TimelineParentPicklist_Test.cls-meta.xml
+++ b/force-app/main/default/classes/TimelineParentPicklist_Test.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>50.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TimelineService.cls
+++ b/force-app/main/default/classes/TimelineService.cls
@@ -400,6 +400,13 @@ public with sharing class TimelineService {
                         .getSobject(objectFieldSplit[3])
                         .get(objectFieldSplit[4])
                 );
+                recordId = String.valueOf(
+                    records.getSobject(objectFieldSplit[0])
+                        .getSobject(objectFieldSplit[1])
+                        .getSobject(objectFieldSplit[2])
+                        .getSobject(objectFieldSplit[3])
+                        .get('Id')
+                );
             }
         }
 
@@ -437,7 +444,7 @@ public with sharing class TimelineService {
 
             fieldDescribeCache.put(key, describeSobjects.fields.getMap().get(fieldName).getDescribe());
         }
-        
+
         return fieldDescribeCache.get(key);
     }
 

--- a/force-app/main/default/classes/TimelineService.cls
+++ b/force-app/main/default/classes/TimelineService.cls
@@ -8,6 +8,8 @@ public with sharing class TimelineService {
      * @param parentFieldName maps API name to use if different from current record
      * @return A map of the API name and label or each child record type to plot on the timeline
      */
+    private static Map<String, Schema.DescribeFieldResult> fieldDescribeCache = new Map<String, Schema.DescribeFieldResult>();
+
     @AuraEnabled(cacheable=true)
     public static Map<String, String> getTimelineTypes(String parentObjectId, String parentFieldName) {
         try {
@@ -36,7 +38,7 @@ public with sharing class TimelineService {
                 String objectLabel = ((SObject) (Type.forName('Schema.' + String.valueOf(timelineType.Object_Name__c))
                         .newInstance()))
                     .getSObjectType()
-                    .getDescribe()
+                    .getDescribe(SObjectDescribeOptions.DEFERRED)
                     .getLabelPlural();
 
                 if (timelineType.Object_Name__c == 'ContentDocumentLink') {
@@ -49,7 +51,7 @@ public with sharing class TimelineService {
                             )
                             .newInstance()))
                         .getSObjectType()
-                        .getDescribe()
+                        .getDescribe(SObjectDescribeOptions.DEFERRED)
                         .getLabelPlural();
                 }
 
@@ -57,6 +59,14 @@ public with sharing class TimelineService {
             }
 
             return mapOfTimelineTypes;
+        } catch (System.QueryException e) {
+            throw new AuraHandledException(
+                '{"type": "Setup-Error", "message": "' +
+                e.getMessage() +
+                ' : ' +
+                e.getStackTraceString() +
+                '"}'
+            );
         } catch (TimelineSetupException e) {
             throw new AuraHandledException(e.getMessage());
         } catch (Exception e) {
@@ -149,7 +159,6 @@ public with sharing class TimelineService {
             }
 
             Map<String, String> childObjects = getChildObjects(parentObjectType);
-            Map<String, FieldMetadata> fieldAttributes = getFieldMetadata(mapOfFields, parentObjectType);
 
             String innerQuery = '';
 
@@ -242,33 +251,13 @@ public with sharing class TimelineService {
                             if (!dupeDataCheck.containsKey(myId)) {
                                 dupeDataCheck.put(myId, myId);
 
-                                Map<String, String> detailValues = getFieldValues(
-                                    tr.detailField,
-                                    eachCh,
-                                    fieldAttributes
-                                );
-                                Map<String, String> positionValues = getFieldValues(
-                                    tr.positionDateField,
-                                    eachCh,
-                                    fieldAttributes
-                                );
-                                Map<String, String> fallbackValues = getFieldValues(
-                                    tr.fallbackTooltipField,
-                                    eachCh,
-                                    fieldAttributes
-                                );
-                                Map<String, String> tooltipIdValues = getFieldValues(
-                                    tr.tooltipIdField,
-                                    eachCh,
-                                    fieldAttributes
-                                );
-                                Map<String, String> drilldownIdValues = getFieldValues(
-                                    tr.drilldownIdField,
-                                    eachCh,
-                                    fieldAttributes
-                                );
+                                Map<String, String> detailValues = getFieldValues(tr.detailField, eachCh);
+                                Map<String, String> positionValues = getFieldValues(tr.positionDateField, eachCh);
+                                Map<String, String> fallbackValues = getFieldValues(tr.fallbackTooltipField, eachCh);
+                                Map<String, String> tooltipIdValues = getFieldValues(tr.tooltipIdField, eachCh);
+                                Map<String, String> drilldownIdValues = getFieldValues(tr.drilldownIdField, eachCh);
 
-                                Map<String, String> typeValues = getFieldValues(tr.type, eachCh, fieldAttributes);
+                                Map<String, String> typeValues = getFieldValues(tr.type, eachCh);
 
                                 if (tr.objectName == 'ContentDocumentLink') {
                                     //NOPMD
@@ -308,6 +297,14 @@ public with sharing class TimelineService {
             return listOfTimelineData;
         } catch (TimelineSetupException e) {
             throw new AuraHandledException(e.getMessage());
+        } catch (System.QueryException e) {
+            throw new AuraHandledException(
+                '{"type": "Setup-Error", "message": "' +
+                e.getMessage() +
+                ' : ' +
+                e.getStackTraceString() +
+                '"}'
+            );
         } catch (Exception e) {
             throw new AuraHandledException(e.getMessage() + ' : ' + e.getStackTraceString());
         }
@@ -338,69 +335,17 @@ public with sharing class TimelineService {
         return childRelatedObjects;
     }
 
-    private static Map<String, FieldMetadata> getFieldMetadata(Map<String, String> fields, String baseObject) {
-        String fieldLabel;
-        Boolean fieldAccess;
-        Map<String, FieldMetadata> mapOfFieldMetadata = new Map<String, FieldMetadata>();
-
-        for (String field : fields.keySet()) {
-            if (field != null && field != '') {
-                String fieldObject = fields.get(field);
-                String fieldStripped = field;
-                String[] objectFieldSplit = field.split('\\.');
-                FieldMetadata fieldMetadata = new fieldMetadata();
-
-                try {
-                    if (objectFieldSplit.size() > 1) {
-                        fieldObject = objectFieldSplit[objectFieldSplit.size() - 2];
-                        fieldStripped = objectFieldSplit[objectFieldSplit.size() - 1];
-                    }
-
-                    if (fieldObject == 'Owner' || fieldObject == 'CreatedBy' || fieldObject == 'LastModifiedBy') {
-                        fieldObject = 'User';
-                    }
-
-                    Schema.DescribeSObjectResult describeSobjects = ((SObject) (Type.forName(
-                                'Schema.' + String.valueOf(fieldObject)
-                            )
-                            .newInstance()))
-                        .getSObjectType()
-                        .getDescribe();
-
-                    fieldMetadata.label = String.valueOf(
-                        describeSobjects.fields.getMap().get(fieldStripped).getDescribe().getLabel()
-                    );
-
-                    fieldMetadata.canAccess = Boolean.valueOf(
-                        describeSobjects.fields.getMap().get(fieldStripped).getDescribe().isAccessible()
-                    );
-                } catch (Exception e) {
-                    String errorMsg =
-                        'No such column \'' +
-                        field +
-                        '\' on entity \'' +
-                        fieldObject +
-                        '\'. If you are attempting to use a custom field, be sure to append the \'__c\' after the custom field name. ' +
-                        e.getMessage();
-                    throw new TimelineSetupException('{"type": "Setup-Error", "message": "' + errorMsg + '"}');
-                }
-
-                mapOfFieldMetadata.put(field, fieldMetadata);
-            }
-        }
-
-        return mapOfFieldMetadata;
-    }
-
-    private static Map<String, String> getFieldValues(
-        String field,
-        Sobject records,
-        Map<String, FieldMetadata> fieldAttributes
-    ) {
+    private static Map<String, String> getFieldValues(String field, Sobject records) {
         Map<String, String> fieldDetails = new Map<String, String>();
 
         String fieldValue = '';
         String fieldLabel = '';
+        String objectCheck = '';
+        String fieldCheck = '';
+        String fieldStripped = '';
+        Boolean fieldCanAccess = true;
+
+        Id recordId;
 
         if (field == null || field == '') {
             fieldDetails.put('value', '');
@@ -408,43 +353,64 @@ public with sharing class TimelineService {
             return fieldDetails;
         }
 
-        FieldMetadata fm = fieldAttributes.get(field);
-        fieldLabel = fm.label;
-
         String[] objectFieldSplit = field.split('\\.');
 
-        if (fm.canAccess) {
-            switch on objectFieldSplit.size() {
-                when 1 {
-                    fieldValue = String.valueOf(records.get(field));
-                }
-                when 2 {
-                    fieldValue = String.valueOf(records.getSobject(objectFieldSplit[0]).get(objectFieldSplit[1]));
-                }
-                when 3 {
-                    fieldValue = String.valueOf(
-                        records.getSobject(objectFieldSplit[0]).getSobject(objectFieldSplit[1]).get(objectFieldSplit[2])
-                    );
-                }
-                when 4 {
-                    fieldValue = String.valueOf(
-                        records.getSobject(objectFieldSplit[0])
-                            .getSobject(objectFieldSplit[1])
-                            .getSobject(objectFieldSplit[2])
-                            .get(objectFieldSplit[3])
-                    );
-                }
-                when 5 {
-                    fieldValue = String.valueOf(
-                        records.getSobject(objectFieldSplit[0])
-                            .getSobject(objectFieldSplit[1])
-                            .getSobject(objectFieldSplit[2])
-                            .getSobject(objectFieldSplit[3])
-                            .get(objectFieldSplit[4])
-                    );
-                }
-            }
+        if (objectFieldSplit.size() > 1) {
+            fieldStripped = objectFieldSplit[objectFieldSplit.size() - 1];
         } else {
+            fieldStripped = field;
+        }
+
+        switch on objectFieldSplit.size() {
+            when 1 {
+                fieldValue = String.valueOf(records.get(field));
+                recordId = String.valueOf(records.get('Id'));
+            }
+            when 2 {
+                fieldValue = String.valueOf(records.getSobject(objectFieldSplit[0]).get(objectFieldSplit[1]));
+                recordId = String.valueOf(records.getSobject(objectFieldSplit[0]).get('Id'));
+            }
+            when 3 {
+                fieldValue = String.valueOf(
+                    records.getSobject(objectFieldSplit[0]).getSobject(objectFieldSplit[1]).get(objectFieldSplit[2])
+                );
+                recordId = String.valueOf(
+                    records.getSobject(objectFieldSplit[0]).getSobject(objectFieldSplit[1]).get('Id')
+                );
+            }
+            when 4 {
+                fieldValue = String.valueOf(
+                    records.getSobject(objectFieldSplit[0])
+                        .getSobject(objectFieldSplit[1])
+                        .getSobject(objectFieldSplit[2])
+                        .get(objectFieldSplit[3])
+                );
+                recordId = String.valueOf(
+                    records.getSobject(objectFieldSplit[0])
+                        .getSobject(objectFieldSplit[1])
+                        .getSobject(objectFieldSplit[2])
+                        .get('Id')
+                );
+            }
+            when 5 {
+                fieldValue = String.valueOf(
+                    records.getSobject(objectFieldSplit[0])
+                        .getSobject(objectFieldSplit[1])
+                        .getSobject(objectFieldSplit[2])
+                        .getSobject(objectFieldSplit[3])
+                        .get(objectFieldSplit[4])
+                );
+            }
+        }
+
+        objectCheck = String.valueOf(recordId.getSobjectType());
+
+        Schema.DescribeFieldResult fieldMetadata = getDescribeInfo(objectCheck, fieldStripped);
+
+        fieldLabel = fieldMetadata.getLabel();
+        fieldCanAccess = fieldMetadata.isAccessible();
+
+        if (fieldCanAccess == false) {
             fieldValue = '![' + fieldLabel + ']!';
         }
 
@@ -456,6 +422,23 @@ public with sharing class TimelineService {
         fieldDetails.put('label', fieldLabel);
 
         return fieldDetails;
+    }
+
+    private static Schema.DescribeFieldResult getDescribeInfo(String objectName, String fieldName) {
+        String key = objectName + fieldName;
+
+        if (!fieldDescribeCache.containsKey(key)) {
+            Schema.DescribeSObjectResult describeSobjects = ((SObject) (Type.forName(
+                        'Schema.' + String.valueOf(objectName)
+                    )
+                    .newInstance()))
+                .getSObjectType()
+                .getDescribe(SObjectDescribeOptions.DEFERRED);
+
+            fieldDescribeCache.put(key, describeSobjects.fields.getMap().get(fieldName).getDescribe());
+        }
+        
+        return fieldDescribeCache.get(key);
     }
 
     private static Boolean isPersonAccount(String recordId) {

--- a/force-app/main/default/classes/TimelineService.cls
+++ b/force-app/main/default/classes/TimelineService.cls
@@ -15,10 +15,15 @@ public with sharing class TimelineService {
         try {
             Map<String, String> parentDetails = getParentDetails(parentObjectId, parentFieldName);
 
-            String parentObjectType = parentDetails.get('ConfigObjectType');
+            String parentObjectType = parentDetails.get('QueryObjectType');
+            String parentConfigType = parentDetails.get('ConfigObjectType');
+            parentObjectId = parentDetails.get('Id');
+
+            Map<String, String> childObjects = getChildObjects(parentObjectType);
 
             String queryTimelineConfiguration =
-                'SELECT Active__c, ' +
+                'SELECT Active__c, ' + 
+                'Relationship_Name__c, ' +
                 'Object_Name__c, ' +
                 'Tooltip_Object_Name__c, ' +
                 'Sequence__c ' +
@@ -27,7 +32,7 @@ public with sharing class TimelineService {
                 'Test__c = ' +
                 Test.isRunningTest() +
                 ' AND ' +
-                'Parent_Object__c =:parentObjectType ' +
+                'Parent_Object__c =:parentConfigType ' +
                 'ORDER BY Sequence__c ASC '; //NOPMD
 
             List<Timeline_Configuration__mdt> listOfTimelineConfigurations = Database.query(queryTimelineConfiguration); //NOPMD
@@ -35,27 +40,37 @@ public with sharing class TimelineService {
             Map<String, String> mapOfTimelineTypes = new Map<String, String>();
 
             for (Timeline_Configuration__mdt timelineType : listOfTimelineConfigurations) {
-                String objectLabel = ((SObject) (Type.forName('Schema.' + String.valueOf(timelineType.Object_Name__c))
-                        .newInstance()))
-                    .getSObjectType()
-                    .getDescribe(SObjectDescribeOptions.DEFERRED)
-                    .getLabelPlural();
 
-                if (timelineType.Object_Name__c == 'ContentDocumentLink') {
-                    objectLabel = System.Label.Timeline_Label_Files;
-                }
-
-                if (timelineType.Tooltip_Object_Name__c != null && timelineType.Tooltip_Object_Name__c != '') {
-                    objectLabel = ((SObject) (Type.forName(
-                                'Schema.' + String.valueOf(timelineType.Tooltip_Object_Name__c)
-                            )
+                if (childObjects.containsKey(timelineType.Object_Name__c + timelineType.Relationship_Name__c) ) {
+                    String objectLabel = ((SObject) (Type.forName('Schema.' + String.valueOf(timelineType.Object_Name__c))
                             .newInstance()))
                         .getSObjectType()
                         .getDescribe(SObjectDescribeOptions.DEFERRED)
                         .getLabelPlural();
-                }
 
-                mapOfTimelineTypes.put(timelineType.Object_Name__c, objectLabel);
+                    if (timelineType.Object_Name__c == 'ContentDocumentLink') {
+                        objectLabel = System.Label.Timeline_Label_Files;
+                    }
+
+                    if (timelineType.Tooltip_Object_Name__c != null && timelineType.Tooltip_Object_Name__c != '') {
+                        objectLabel = ((SObject) (Type.forName(
+                                    'Schema.' + String.valueOf(timelineType.Tooltip_Object_Name__c)
+                                )
+                                .newInstance()))
+                            .getSObjectType()
+                            .getDescribe(SObjectDescribeOptions.DEFERRED)
+                            .getLabelPlural();
+                    }
+
+                    mapOfTimelineTypes.put(timelineType.Object_Name__c, objectLabel);
+                }
+                else {
+                    String errorMsg =
+                    'You have asked to plot records for  \'' +
+                    timelineType.Object_Name__c +
+                    '\' but this entity cannot be found. Ask an administrator for help.';
+                    throw new TimelineSetupException('{"type": "Setup-Error", "message": "' + errorMsg + '"}');
+                }
             }
 
             return mapOfTimelineTypes;

--- a/force-app/main/default/classes/TimelineService.cls-meta.xml
+++ b/force-app/main/default/classes/TimelineService.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>50.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/TimelineService_Test.cls-meta.xml
+++ b/force-app/main/default/classes/TimelineService_Test.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>50.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Asset_AssetRelationships.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Asset_AssetRelationships.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Asset_AssetRelationships</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">AssetRelationshipNumber</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#FA975C</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/asset_relationship.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">AssetRelationship</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Asset</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">FromDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">PrimaryAssets</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">50.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Asset_Cases.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Asset_Cases.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Asset_Cases</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Subject</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#f2d05a</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/case.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">Case</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Asset</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">CreatedDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">Cases</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">40.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Asset_ChildAssets.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Asset_ChildAssets.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Asset_ChildAssets</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Description</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#317992</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/asset_object.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">Asset</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Asset</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">InstallDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">ChildAssets</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">50.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Asset_ContractLineItems.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Asset_ContractLineItems.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Asset_ContractLineItems</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Description</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#6EC06E</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/contract_line_item.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">ContractLineItem</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Asset</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">StartDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">ContractLineItems</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">50.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Asset_DowntimePeriods.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Asset_DowntimePeriods.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Asset_DowntimePeriods</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Description</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">DowntimeType</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#317992</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/asset_downtime_period.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">AssetDowntimePeriod</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Asset</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">StartTime</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">AssetDowntimePeriods</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">50.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Asset_Entitlements.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Asset_Entitlements.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Asset_Entitlements</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Name</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#7E8BE4</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/entitlement_120.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">Entitlement</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Asset</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">StartDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">Entitlements</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">50.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Asset_Events.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Asset_Events.md-meta.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Asset_Events</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Subject</value>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">Description</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#eb7092</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/event.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">Event</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Asset</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">StartDateTime</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">Events</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">20.0</value>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Asset_Files.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Asset_Files.md-meta.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Asset_Files</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">ContentDocument.Title</value>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">ContentDocument.FileExtension</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#b19f7e</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/document.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">ContentDocumentLink</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Asset</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">SystemModstamp</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">ContentDocumentLinks</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">30.0</value>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:type="xsd:string">ContentDocument.FileType</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Asset_MaintenanceAssets.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Asset_MaintenanceAssets.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Asset_MaintenanceAssets</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">MaintenancePlan.MaintenancePlanTitle</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:type="xsd:string">MaintenancePlanId</value>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#2A739E</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/maintenance_asset.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">MaintenanceAsset</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Asset</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">MaintenancePlan.StartDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">MaintenanceAssets</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">40.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:type="xsd:string">MaintenancePlanId</value>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:type="xsd:string">MaintenancePlan</value>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Asset_ReturnOrderLineItems.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Asset_ReturnOrderLineItems.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Asset_ReturnOrderLineItems</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Description</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#009688</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/return_order.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">ReturnOrderLineItem</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Asset</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">CreatedDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">ReturnOrderLineItems</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">50.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Asset_Tasks.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Asset_Tasks.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Asset_Tasks</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Subject</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">Description</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#4ac076</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/task.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">Task</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Asset</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">ActivityDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">Tasks</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">10.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Lead_CampaignMembers.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Lead_CampaignMembers.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Lead_CampaignMembers</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Campaign.Name</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#f49756</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/campaign.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">CampaignMember</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Lead</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">Campaign.StartDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">CampaignMembers</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">60.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Lead_EventRelations.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Lead_EventRelations.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Lead_EventRelations</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Event.Subject</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:type="xsd:string">Event.Id</value>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">Event.Description</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#eb7092</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/event.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">EventRelation</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Lead</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">Event.StartDateTime</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">EventRelations</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">20.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:type="xsd:string">Event.Id</value>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:type="xsd:string">Event</value>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Lead_Events.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Lead_Events.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Lead_Events</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Subject</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">Description</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#eb7092</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/event.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">Event</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Lead</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">StartDateTime</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">Events</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">20.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Lead_Files.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Lead_Files.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Lead_Files</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">ContentDocument.Title</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">ContentDocument.FileExtension</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#b19f7e</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/document.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">ContentDocumentLink</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Lead</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">SystemModstamp</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">ContentDocumentLinks</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">30.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:type="xsd:string">ContentDocument.FileType</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Lead_TaskRelations.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Lead_TaskRelations.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Lead_TaskRelations</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Task.Subject</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:type="xsd:string">Task.Id</value>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">Task.Description</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#4ac076</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/task.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">TaskRelation</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Lead</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">Task.ActivityDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">TaskRelations</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">10.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:type="xsd:string">Task.Id</value>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:type="xsd:string">Task</value>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:type="xsd:string">Task.TaskSubtype</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Lead_Tasks.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Lead_Tasks.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Lead_Tasks</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Subject</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">Description</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#4ac076</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/task.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">Task</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Lead</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">ActivityDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">Tasks</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">10.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:type="xsd:string">TaskSubtype</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Opportunity_ContactRoles.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Opportunity_ContactRoles.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opportunity_ContactRoles</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Contact.Name</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:type="xsd:string">ContactId</value>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">Role</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#7e8be4</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/opportunity_contact_role.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">OpportunityContactRole</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">CreatedDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">OpportunityContactRoles</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">40.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Opportunity_Events.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Opportunity_Events.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opportunity_Events</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Subject</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">Description</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#eb7092</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/event.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">Event</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">StartDateTime</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">Events</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">20.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Opportunity_Files.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Opportunity_Files.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opportunity_Files</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">ContentDocument.Title</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">ContentDocument.FileExtension</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#b19f7e</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/document.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">ContentDocumentLink</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">SystemModstamp</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">ContentDocumentLinks</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">30.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:type="xsd:string">ContentDocument.FileType</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Opportunity_LineItems.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Opportunity_LineItems.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opportunity_LineItems</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Product2.Name</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#FCB95B</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/product.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">OpportunityLineItem</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">CreatedDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">OpportunityLineItems</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">60.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Opportunity_Partners.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Opportunity_Partners.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opportunity_Partners</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">AccountTo.Name</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:type="xsd:string">AccountToId</value>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">Role</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#3c97dd</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/relationship.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">OpportunityPartner</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">CreatedDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">OpportunityPartnersFrom</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">50.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.Opportunity_Tasks.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.Opportunity_Tasks.md-meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>Opportunity_Tasks</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Subject</value>
+    </values>
+    <values>
+        <field>Drilldown_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">Description</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#4ac076</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/task.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">Task</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">Opportunity</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">ActivityDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">Tasks</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">10.0</value>
+    </values>
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:boolean">false</value>
+    </values>
+    <values>
+        <field>Tooltip_Id_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Tooltip_Object_Name__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:type="xsd:string">TaskSubtype</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.WorkOrder_ChildWorkOrders.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.WorkOrder_ChildWorkOrders.md-meta.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>WorkOrder_ChildWorkOrders</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Subject</value>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string"></value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#7e8be4</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/service_appointment.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">WorkOrder</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">WorkOrder</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">StartDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">ChildWorkOrders</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">60.0</value>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:type="xsd:string"></value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.WorkOrder_Events.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.WorkOrder_Events.md-meta.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>WorkOrder_Events</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Subject</value>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">Description</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#eb7092</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/event.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">Event</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">WorkOrder</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">StartDateTime</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">Events</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">20.0</value>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:nil="true"/>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.WorkOrder_Files.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.WorkOrder_Files.md-meta.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>WorkOrder_Files</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">ContentDocument.Title</value>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">ContentDocument.FileExtension</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#b19f7e</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/document.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">ContentDocumentLink</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">WorkOrder</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">SystemModstamp</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">ContentDocumentLinks</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">30.0</value>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:type="xsd:string">ContentDocument.FileType</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.WorkOrder_ServiceAppointments.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.WorkOrder_ServiceAppointments.md-meta.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>WorkOrder_ServiceAppointments</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Subject</value>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string"></value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#7e8be4</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/service_appointment.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">ServiceAppointment</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">WorkOrder</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">SchedStartTime</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">ServiceAppointments</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">60.0</value>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:type="xsd:string"></value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.WorkOrder_Tasks.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.WorkOrder_Tasks.md-meta.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>WorkOrder_Tasks</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Subject</value>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string">Description</value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#4ac076</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/task.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">Task</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">WorkOrder</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">ActivityDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">Tasks</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">10.0</value>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:type="xsd:string">TaskSubtype</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/Timeline_Configuration.WorkOrder_WorkOrderLineItems.md-meta.xml
+++ b/force-app/main/default/customMetadata/Timeline_Configuration.WorkOrder_WorkOrderLineItems.md-meta.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>WorkOrder_WorkOrderLineItems</label>
+    <protected>false</protected>
+    <values>
+        <field>Active__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>Detail_Field__c</field>
+        <value xsi:type="xsd:string">Description</value>
+    </values>
+    <values>
+        <field>Fallback_Tooltip_Field__c</field>
+        <value xsi:type="xsd:string"></value>
+    </values>
+    <values>
+        <field>Icon_Background_Colour__c</field>
+        <value xsi:type="xsd:string">#33a8dc</value>
+    </values>
+    <values>
+        <field>Icon__c</field>
+        <value xsi:type="xsd:string">/img/icon/t4v35/standard/work_order_item.svg</value>
+    </values>
+    <values>
+        <field>Object_Name__c</field>
+        <value xsi:type="xsd:string">WorkOrderLineItem</value>
+    </values>
+    <values>
+        <field>Parent_Object__c</field>
+        <value xsi:type="xsd:string">WorkOrder</value>
+    </values>
+    <values>
+        <field>Position_Date_Field__c</field>
+        <value xsi:type="xsd:string">StartDate</value>
+    </values>
+    <values>
+        <field>Relationship_Name__c</field>
+        <value xsi:type="xsd:string">WorkOrderLineItems</value>
+    </values>
+    <values>
+        <field>Sequence__c</field>
+        <value xsi:type="xsd:double">70.0</value>
+    </values>
+    <values>
+        <field>Type_Field__c</field>
+        <value xsi:type="xsd:string"></value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/layouts/Timeline_Configuration__mdt-Timeline Configuration Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Timeline_Configuration__mdt-Timeline Configuration Layout.layout-meta.xml
@@ -67,7 +67,7 @@
         <customLabel>true</customLabel>
         <detailHeading>true</detailHeading>
         <editHeading>true</editHeading>
-        <label>Icon and background colour to use</label>
+        <label>Icon and background colour to use for each record</label>
         <layoutColumns>
             <layoutItems>
                 <behavior>Required</behavior>
@@ -86,7 +86,7 @@
         <customLabel>true</customLabel>
         <detailHeading>true</detailHeading>
         <editHeading>true</editHeading>
-        <label>Field on &lt;Object_Name__c&gt; to show in Tooltip (only when needed)</label>
+        <label>API name of field to use in tooltips (Optional)</label>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -100,7 +100,7 @@
         <customLabel>true</customLabel>
         <detailHeading>true</detailHeading>
         <editHeading>true</editHeading>
-        <label>Id Field on &lt;Object_Name__c&gt; with Id to drilldown to when user clicks a record</label>
+        <label>Override the record shown when a user clicks on a record. (Optional)</label>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>
@@ -114,7 +114,7 @@
         <customLabel>true</customLabel>
         <detailHeading>true</detailHeading>
         <editHeading>true</editHeading>
-        <label>Id Field on &lt;Object_Name__c&gt; to show when user hovers</label>
+        <label>If the UI API is supported but you want a related record shown. (Optional)</label>
         <layoutColumns>
             <layoutItems>
                 <behavior>Edit</behavior>

--- a/force-app/main/default/lwc/illustration/illustration.js-meta.xml
+++ b/force-app/main/default/lwc/illustration/illustration.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>50.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/force-app/main/default/lwc/timeline/timeline.html
+++ b/force-app/main/default/lwc/timeline/timeline.html
@@ -8,7 +8,7 @@
                     <h1 class="slds-text-heading_medium">{timelineTitle}</h1>
                 </template>
                 <template if:false={isLoaded}>
-                    <div class="stencil-value" style="margin-left: 10px;"></div>
+                    <div class="stencil-value" style="margin-left: 10px"></div>
                 </template>
             </div>
             <div class="slds-col slds-shrink-none slds-align-middle">
@@ -75,7 +75,7 @@
                 class="timeline-filter slds-float_right slds-panel slds-size_small slds-panel_docked slds-panel_docked-right"
                 aria-hidden="false"
             >
-                <div class="slds-panel__header" style="height: 50px;">
+                <div class="slds-panel__header" style="height: 50px">
                     <template if:false={isFilterUpdated}>
                         <h2 class="slds-panel__header-title slds-text-heading_small slds-truncate" title="Panel Header">
                             {label.FILTERS}
@@ -94,7 +94,7 @@
                     </template>
 
                     <template if:true={isFilterUpdated}>
-                        <div class="slds-grid" style="width: 100%;">
+                        <div class="slds-grid" style="width: 100%">
                             <div>
                                 <lightning-button
                                     label={label.BUTTON_CANCEL}
@@ -146,12 +146,10 @@
                         </lightning-checkbox-group>
                     </template>
 
-                    <div style="padding-top: 10px;"></div>
+                    <div style="padding-top: 10px"></div>
                     <legend class="slds-form-element__label slds-text-title_caps">{label.DATE_RANGE_LEGEND}</legend>
 
-                    <div class="slds-form-element__label" style="padding-top: 5px;">
-                        {timelineStart} - {timelineEnd}
-                    </div>
+                    <div class="slds-form-element__label" style="padding-top: 5px">{timelineStart} - {timelineEnd}</div>
                 </div>
             </div>
         </div>

--- a/force-app/main/default/lwc/timeline/timeline.js
+++ b/force-app/main/default/lwc/timeline/timeline.js
@@ -600,9 +600,9 @@ export default class timeline extends NavigationMixin(LightningElement) {
                             }
                             case 'CaseComment': {
                                 const event = new ShowToastEvent({
-                                    "title": me.toast.NAVIGATION_HEADER,
-                                    "message": me.toast.NAVIGATION_BODY,
-                                    "messageData": [d.objectName]
+                                    title: me.toast.NAVIGATION_HEADER,
+                                    message: me.toast.NAVIGATION_BODY,
+                                    messageData: [d.objectName]
                                 });
                                 this.dispatchEvent(event);
                                 break;

--- a/force-app/main/default/lwc/timeline/timeline.js
+++ b/force-app/main/default/lwc/timeline/timeline.js
@@ -194,10 +194,9 @@ export default class timeline extends NavigationMixin(LightningElement) {
             let timelineDIV = this.template.querySelector('div.timeline-canvas');
             this.currentParentField = this.timelineParent;
 
-            if ( this.flexipageRegionWidth == undefined ) {
+            if (this.flexipageRegionWidth === undefined) {
                 this.timelineWidth = 'LARGE';
-            }
-            else {
+            } else {
                 this.timelineWidth = this.flexipageRegionWidth;
             }
 
@@ -587,7 +586,7 @@ export default class timeline extends NavigationMixin(LightningElement) {
                         }
 
                         switch (d.objectName) {
-                            case 'ContentDocumentLink':
+                            case 'ContentDocumentLink': {
                                 me[NavigationMixin.Navigate]({
                                     type: 'standard__namedPage',
                                     attributes: {
@@ -598,17 +597,17 @@ export default class timeline extends NavigationMixin(LightningElement) {
                                     }
                                 });
                                 break;
-                            case 'CaseComment': 
+                            }
+                            case 'CaseComment': {
                                 const event = new ShowToastEvent({
                                     "title": me.toast.NAVIGATION_HEADER,
                                     "message": me.toast.NAVIGATION_BODY,
-                                    "messageData": [
-                                        d.objectName
-                                    ]
+                                    "messageData": [d.objectName]
                                 });
                                 this.dispatchEvent(event);
                                 break;
-                            default:
+                            }
+                            default: {
                                 me[NavigationMixin.Navigate]({
                                     type: 'standard__recordPage',
                                     attributes: {
@@ -617,6 +616,7 @@ export default class timeline extends NavigationMixin(LightningElement) {
                                     }
                                 });
                                 break;
+                            }
                         }
                     })
                     .on('mouseover', function (d) {

--- a/force-app/main/default/lwc/timeline/timeline.js
+++ b/force-app/main/default/lwc/timeline/timeline.js
@@ -169,7 +169,7 @@ export default class timeline extends NavigationMixin(LightningElement) {
                 let customError = JSON.parse(errorMessage);
                 errorType = customError.type;
                 errorMessage = customError.message;
-                errorHeading = this.error.NO_DATA_HEADER;
+                errorHeading = this.error.SETUP;
             } catch (error2) {
                 //fails to parse message so is a generic apex error
                 errorHeading = this.error.APEX;

--- a/force-app/main/default/lwc/timeline/timeline.js-meta.xml
+++ b/force-app/main/default/lwc/timeline/timeline.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata" fqn="timeline">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>50.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Time Warp</masterLabel>
     <targets>
@@ -10,14 +10,7 @@
     </targets>
     <targetConfigs>
         <targetConfig targets="lightning__RecordPage">
-            <objects>
-                <object>Contact</object>
-                <object>Lead</object>
-                <object>Account</object>
-                <object>Case</object>
-                <object>Opportunity</object>
-            </objects>
-
+            
             <property name="timelineParent" label="Parent Record" type="String" datasource="apex://TimelineParentPicklist" required="true" />
             <property name="timelineTitle" label="Title" default="Timeline" required="true" type="String" />
             <property name="preferredHeight" label="Height" default="3 - Default" required="true" type="String" datasource="1 - Smallest, 2 - Small, 3 - Default, 4 - Big, 5 - Biggest" />

--- a/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Active__c.field-meta.xml
+++ b/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Active__c.field-meta.xml
@@ -4,7 +4,7 @@
     <defaultValue>true</defaultValue>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
-    <inlineHelpText>Inactivate records to ignore them from the timeline lwc</inlineHelpText>
+    <inlineHelpText>Inactivate records to hide them from the timeline lwc</inlineHelpText>
     <label>Active</label>
     <type>Checkbox</type>
 </CustomField>

--- a/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Detail_Field__c.field-meta.xml
+++ b/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Detail_Field__c.field-meta.xml
@@ -5,7 +5,7 @@
     <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>The field to use to show against each record on the timeline lwc as a short description (30 chars shown)</inlineHelpText>
     <label>Detail Field</label>
-    <length>75</length>
+    <length>150</length>
     <required>true</required>
     <type>Text</type>
     <unique>false</unique>

--- a/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Drilldown_Id_Field__c.field-meta.xml
+++ b/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Drilldown_Id_Field__c.field-meta.xml
@@ -5,9 +5,9 @@
     <description>The Id field to use when navigating on click of a record in the timeline. Used to support the ability to show a junction object record but drill into a parent.</description>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
-    <inlineHelpText>The Id field to use when navigating on click of a record in the timeline. If blank the Id of the record plotted will be used.</inlineHelpText>
+    <inlineHelpText>Override the record shown when a user clicks on a record. The Id field to use when navigating goes here.</inlineHelpText>
     <label>Drilldown Id Field</label>
-    <length>100</length>
+    <length>150</length>
     <required>false</required>
     <type>Text</type>
     <unique>false</unique>

--- a/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Fallback_Tooltip_Field__c.field-meta.xml
+++ b/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Fallback_Tooltip_Field__c.field-meta.xml
@@ -5,7 +5,7 @@
     <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>The API Name of the field to use in tooltips when the object is not supported by the UI API</inlineHelpText>
     <label>Fallback Tooltip Field</label>
-    <length>100</length>
+    <length>150</length>
     <required>false</required>
     <type>Text</type>
     <unique>false</unique>

--- a/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Object_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Object_Name__c.field-meta.xml
@@ -5,7 +5,7 @@
     <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>The sObject API Name that defines the child record</inlineHelpText>
     <label>Object Name</label>
-    <length>100</length>
+    <length>150</length>
     <required>true</required>
     <type>Text</type>
     <unique>false</unique>

--- a/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Parent_Object__c.field-meta.xml
+++ b/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Parent_Object__c.field-meta.xml
@@ -5,7 +5,7 @@
     <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>The Parent Objects API Name that the child record applies to</inlineHelpText>
     <label>Parent Object</label>
-    <length>100</length>
+    <length>150</length>
     <required>true</required>
     <type>Text</type>
     <unique>false</unique>

--- a/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Relationship_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Relationship_Name__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description>The API name corresponding to the relationship between the objects.</description>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
-    <inlineHelpText>The API name corresponding to the relationship between the objects.</inlineHelpText>
+    <inlineHelpText>The API name corresponding to the relationship between the objects. Note that custom relationships end with __r.</inlineHelpText>
     <label>Relationship Name</label>
     <length>255</length>
     <required>true</required>

--- a/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Sequence__c.field-meta.xml
+++ b/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Sequence__c.field-meta.xml
@@ -4,7 +4,7 @@
     <defaultValue>50</defaultValue>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
-    <inlineHelpText>The order the object appears in the filter</inlineHelpText>
+    <inlineHelpText>The order the object appears in the filter panel on the right hand side of the timeline</inlineHelpText>
     <label>Sequence</label>
     <precision>3</precision>
     <required>true</required>

--- a/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Tooltip_Id_Field__c.field-meta.xml
+++ b/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Tooltip_Id_Field__c.field-meta.xml
@@ -5,9 +5,9 @@
     <description>The Id field to use when hovering over a record in the timeline. Used to support the ability to show a junction object record but show detail of the parent.</description>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
-    <inlineHelpText>The Id field to use when hovering over a record in the timeline. If blank the Id of the record plotted will be used.</inlineHelpText>
+    <inlineHelpText>If the UI API is supported but you want a related record shown specify the Id field to use when hovering here.</inlineHelpText>
     <label>Tooltip Id Field</label>
-    <length>100</length>
+    <length>150</length>
     <required>false</required>
     <type>Text</type>
     <unique>false</unique>

--- a/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Tooltip_Object_Name__c.field-meta.xml
+++ b/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Tooltip_Object_Name__c.field-meta.xml
@@ -4,9 +4,9 @@
     <description>The sObject API name for the tooltip.</description>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
-    <inlineHelpText>The sObject API name for the tooltip.</inlineHelpText>
+    <inlineHelpText>If the UI API is supported but you want a related record shown specify the sObject API name to use when hovering here.</inlineHelpText>
     <label>Tooltip Object Name</label>
-    <length>100</length>
+    <length>150</length>
     <required>false</required>
     <type>Text</type>
     <unique>false</unique>

--- a/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Type_Field__c.field-meta.xml
+++ b/force-app/main/default/objects/Timeline_Configuration__mdt/fields/Type_Field__c.field-meta.xml
@@ -5,7 +5,7 @@
     <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>The field used for Task sObject type only</inlineHelpText>
     <label>Type Field</label>
-    <length>100</length>
+    <length>150</length>
     <required>false</required>
     <type>Text</type>
     <unique>false</unique>

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     },
     "devDependencies": {
         "@salesforce/eslint-config-lwc": "^0.7.0",
-        "@salesforce/sfdx-lwc-jest": "^0.7.1",
-        "eslint": "^7.1.0",
-        "prettier": "^2.0.5",
-        "prettier-plugin-apex": "^1.5.0",
+        "@salesforce/sfdx-lwc-jest": "^0.10.2",
+        "eslint": "^7.14.0",
+        "prettier": "^2.2.0",
+        "prettier-plugin-apex": "^1.7.0",
         "semver": "^7.3.2"
     },
     "repository": {

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -9,7 +9,7 @@
     ],
     "namespace": "bmpyrckt",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "49.0",
+    "sourceApiVersion": "50.0",
     "packageAliases": {
         "TimeWarp": "0Ho2w000000TNVlCAO",
         "TimeWarp@1.2.0-1": "04t2w000008K1N2AAK",


### PR DESCRIPTION
Added support for custom and all standard objects
Updated Parent Field to support valid objects
Fixed defect with custom relationship names in dot notation
Performance improvements with describe caching
Added defaults for Leads and Opportunities
Added defaults for Assets
Fixed error handling when Object is not found in the Org
Extended field lengths in mdt and improved tooltips
API version incremented 49->50