### PR TITLE
Added null checks for date values

### DIFF
--- a/force-app/main/default/classes/TimelineService.cls
+++ b/force-app/main/default/classes/TimelineService.cls
@@ -336,7 +336,9 @@ public with sharing class TimelineService {
                                 mapData.put('icon', tr.icon);
                                 mapData.put('iconBackground', tr.iconBackground);
 
-                                listOfTimelineData.add(mapData);
+                                if ( positionValues.get('value') != null && positionValues.get('value') != '') {
+                                    listOfTimelineData.add(mapData);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Checks to see if date values are null before returning them to the browser to cater for the fact that ActivityHistory and OpenActivities cannot include where clauses for non-admin users