### PR TITLE
fix: rtl-title-padding

### DIFF
--- a/force-app/main/default/lwc/timeline/timeline.css
+++ b/force-app/main/default/lwc/timeline/timeline.css
@@ -224,6 +224,7 @@
     font-weight: 500;
     font-size: 1rem;
     padding-left: 10px;
+    padding-right: 10px;
     line-height: 1.25;
 }
 


### PR DESCRIPTION
Fix the right padding when the title shows in a right to left language