### PR TITLE
fix: ignore timezone for fields of type date

### DIFF
--- a/force-app/main/default/classes/TimelineService.cls
+++ b/force-app/main/default/classes/TimelineService.cls
@@ -348,6 +348,7 @@ public with sharing class TimelineService {
                                 mapData.put('detailFieldLabel', detailValues.get('label'));
                                 mapData.put('positionDateField', positionValues.get('label'));
                                 mapData.put('positionDateValue', positionValues.get('value'));
+                                mapData.put('positionDateType', positionValues.get('type'));
                                 mapData.put('objectName', tr.objectName);
                                 mapData.put('fallbackTooltipField', fallbackValues.get('label'));
                                 mapData.put('fallbackTooltipValue', fallbackValues.get('value'));
@@ -421,6 +422,7 @@ public with sharing class TimelineService {
 
         String fieldValue = '';
         String fieldLabel = '';
+        String fieldType = '';
         String objectCheck = '';
         //String fieldCheck = '';
         String fieldStripped = '';
@@ -512,6 +514,7 @@ public with sharing class TimelineService {
 
         fieldLabel = fieldMetadata.getLabel();
         fieldCanAccess = fieldMetadata.isAccessible();
+        fieldType = String.valueOf(fieldMetadata.getType());
 
         if (fieldCanAccess == false) {
             fieldValue = '![' + fieldLabel + ']!';
@@ -523,6 +526,7 @@ public with sharing class TimelineService {
 
         fieldDetails.put('value', fieldValue);
         fieldDetails.put('label', fieldLabel);
+        fieldDetails.put('type', fieldType);
 
         return fieldDetails;
     }
@@ -634,6 +638,7 @@ public with sharing class TimelineService {
         private String iconBackgroundField;
         private String positionDateField;
         private String positionDateValue;
+        private String positionDateType;
         private String objectName;
         private String type;
         private String tooltipIdField;

--- a/force-app/main/default/lwc/timeline/timeline.js
+++ b/force-app/main/default/lwc/timeline/timeline.js
@@ -440,19 +440,9 @@ export default class timeline extends NavigationMixin(LightningElement) {
         let timelineResult = [];
         let timelineTimes = [];
 
-        const options = {
-            hour: 'numeric',
-            minute: 'numeric',
-            year: 'numeric',
-            month: 'numeric',
-            day: 'numeric',
-            timeZone: TIMEZONE
-        };
-
-        const dateFormatter = new Intl.DateTimeFormat(me.calculatedLOCALE(), options);
-
         result.forEach(function (record, index) {
             let recordCopy = {};
+            let options;
 
             recordCopy.recordId = record.objectId;
             recordCopy.id = index;
@@ -461,9 +451,34 @@ export default class timeline extends NavigationMixin(LightningElement) {
             recordCopy.objectName = record.objectName;
             recordCopy.positionDateField = record.positionDateField;
 
-            let convertDate = record.positionDateValue.replace(' ', 'T');
-            convertDate = convertDate + '.000Z';
+            if (record.positionDateType === 'DATE') {
+                options = {
+                    year: 'numeric',
+                    month: 'numeric',
+                    day: 'numeric'
+                };
+            }      
+            else {
+                options = {
+                    hour: 'numeric',
+                    minute: 'numeric',
+                    year: 'numeric',
+                    month: 'numeric',
+                    day: 'numeric',
+                    timeZone: TIMEZONE
+                };
+            }  
 
+            let dateFormatter = new Intl.DateTimeFormat(me.calculatedLOCALE(), options);
+
+            let convertDate = record.positionDateValue;
+            
+
+            if (record.positionDateType === 'DATETIME') {
+                convertDate = record.positionDateValue.replace(' ', 'T');
+                convertDate = convertDate + '.000Z';
+            }
+            
             let localDate = new Date(convertDate);
             let localPositionDate = dateFormatter.format(localDate);
 
@@ -472,10 +487,8 @@ export default class timeline extends NavigationMixin(LightningElement) {
 
             recordCopy.detailField = record.detailField;
             recordCopy.detailFieldLabel = record.detailFieldLabel;
-
             recordCopy.fallbackTooltipField = record.fallbackTooltipField;
             recordCopy.fallbackTooltipValue = record.fallbackTooltipValue;
-
             recordCopy.tooltipId = record.tooltipId;
             recordCopy.tooltipObject = record.tooltipObject;
             recordCopy.drilldownId = record.drilldownId;


### PR DESCRIPTION
Ignores timezone when formatting dates for date fields of type date. Fields of type DateTime continue to be adjusted based on the users locale.