### PR TITLE
feat: tooltip viewport

### DIFF
--- a/force-app/main/default/lwc/timeline/timeline.css
+++ b/force-app/main/default/lwc/timeline/timeline.css
@@ -23,7 +23,8 @@
     text-align: center;
 }
 
-.slds-spinner_container, .slds-spinner--container {
+.slds-spinner_container,
+.slds-spinner--container {
     border-radius: 20px !important;
 }
 
@@ -115,7 +116,9 @@
 
 /* axis labels */
 .axis-ticks {
-    font-family: Salesforce Sans, sans-serif;
+    font-family:
+        Salesforce Sans,
+        sans-serif;
     font-size: 10px;
 }
 
@@ -273,10 +276,61 @@
     display: inline-block;
     box-shadow: 0 2px 3px 0 rgb(0 0 0 / 16%);
     border: 1px solid #dddbda;
+    position: relative;
 }
 
+/* Nubbin styles */
+.slds-nubbin_left-top:before,
+.slds-nubbin_left-top:after,
+.slds-nubbin_right-top:before,
+.slds-nubbin_right-top:after {
+    width: 1rem;
+    height: 1rem;
+    position: absolute;
+    transform: rotate(45deg);
+    content: '';
+    background-color: inherit;
+    left: 50%;
+    top: 50%;
+    margin-top: -0.5rem;
+}
+
+.slds-nubbin_left-top:before,
+.slds-nubbin_right-top:before {
+    --background-color: #dddbda;
+    margin-left: -0.5rem;
+}
+
+.slds-nubbin_left-top:after,
+.slds-nubbin_right-top:after {
+    --background-color: rgb(243, 242, 242);
+    margin-left: -0.5rem;
+}
+
+.slds-nubbin_left-top:before,
 .slds-nubbin_left-top:after {
-    box-shadow: 0px 0px 0px 0px rgb(0 0 0 / 16%) !important;
+    left: 0rem;
+}
+
+.slds-nubbin_right-top:before,
+.slds-nubbin_right-top:after {
+    left: auto;
+    right: -0.5rem;
+}
+
+.slds-nubbin_left-top:before,
+.slds-nubbin_left-top:after,
+.slds-nubbin_right-top:before,
+.slds-nubbin_right-top:after {
+    top: 2.4rem;
+}
+
+.slds-nubbin_left-bottom:before,
+.slds-nubbin_left-bottom:after,
+.slds-nubbin_right-bottom:before,
+.slds-nubbin_right-bottom:after {
+    top: auto;
+    bottom: 0.75rem;
 }
 
 @media only screen and (max-width: 900px) {

--- a/force-app/main/default/lwc/timeline/timeline.html
+++ b/force-app/main/default/lwc/timeline/timeline.html
@@ -173,7 +173,7 @@
     </article>
 
     <!--tooltips FALLBACK WHEN AN OBJECT IS NOT SUPPORTED-->
-    <div aria-label="Tooltip popover" class="tooltip-panel tooltip-popover slds-popover_panel slds-nubbin_left-top">
+    <div aria-label="Tooltip popover" class={tooltipClass}>
         <div class="tooltip-content">
             <template lwc:if={showFallbackTooltip}>
                 <div class="slds-form" role="list">

--- a/force-app/main/default/lwc/timeline/timeline.js
+++ b/force-app/main/default/lwc/timeline/timeline.js
@@ -85,6 +85,7 @@ export default class timeline extends NavigationMixin(LightningElement) {
     mouseOverFallbackValue;
     mouseOverPositionLabel;
     mouseOverPositionValue;
+    nubbinClass = 'slds-nubbin_left-top'; // Default nubbin class
 
     currentParentField;
     filterValues = [];
@@ -862,26 +863,75 @@ export default class timeline extends NavigationMixin(LightningElement) {
                         me.isMouseOver = true;
                         let tooltipDIV = me.template.querySelector('div.tooltip-panel');
                         let tipPosition;
-
-                        switch (me.isLanguageRightToLeft) {
-                            case true:
-                                tipPosition =
-                                    this.getBoundingClientRect().top -
-                                    30 +
-                                    'px ;left:' +
-                                    (this.getBoundingClientRect().left - tooltipDIV.offsetWidth - 15) +
-                                    'px ;visibility:visible';
-                                break;
-                            default:
-                                tipPosition =
-                                    this.getBoundingClientRect().top -
-                                    30 +
-                                    'px ;left:' +
-                                    (this.getBoundingClientRect().right + 15) +
-                                    'px ;visibility:visible';
-                                break;
+                        
+                        // Get viewport dimensions
+                        const viewportWidth = window.innerWidth;
+                        const viewportHeight = window.innerHeight;
+                        
+                        // Get element position and dimensions
+                        const elementRect = this.getBoundingClientRect();
+                        const tooltipWidth = tooltipDIV.offsetWidth;
+                        const tooltipHeight = tooltipDIV.offsetHeight;
+                        
+                        // Calculate available space on each side
+                        const spaceRight = viewportWidth - elementRect.right;
+                        const spaceLeft = elementRect.left;
+                        
+                        // Default vertical position (centered with element)
+                        let top = elementRect.top - 30;
+                        
+                        // Adjust vertical position if tooltip would be cut off
+                        if (top < 0) {
+                            top = 10; // Add some padding from top
+                        } else if (top + tooltipHeight > viewportHeight) {
+                            top = viewportHeight - tooltipHeight - 10; // Add some padding from bottom
                         }
-                        tooltipDIV.setAttribute('style', 'top:' + tipPosition);
+                        
+                        // Determine horizontal position based on available space and language direction
+                        let left;
+                        let showOnRight = true;
+                        let hasEnoughSpace = false;
+                        
+                        if (me.isLanguageRightToLeft) {
+                            // For RTL, prefer left side if there's enough space
+                            if (spaceLeft >= tooltipWidth + 15) {
+                                left = elementRect.left - tooltipWidth - 15;
+                                showOnRight = false;
+                                hasEnoughSpace = true;
+                            } else {
+                                // If not enough space on left, try right side
+                                left = elementRect.right + 15;
+                                showOnRight = true;
+                            }
+                        } else {
+                            // For LTR, try right side first
+                            if (spaceRight >= tooltipWidth + 15) {
+                                // Enough space on right
+                                left = elementRect.right + 15;
+                                showOnRight = true;
+                                hasEnoughSpace = true;
+                            } else if (spaceLeft >= tooltipWidth + 15) {
+                                // Not enough space on right, but enough on left
+                                left = elementRect.left - tooltipWidth - 15;
+                                showOnRight = false;
+                                hasEnoughSpace = true;
+                            } else {
+                                // Not enough space on either side, force right
+                                left = elementRect.right + 15;
+                                showOnRight = true;
+                            }
+                        }
+                        
+                        // Only ensure tooltip stays within viewport if we had enough space on preferred side
+                        if (hasEnoughSpace) {
+                            left = Math.max(10, Math.min(left, viewportWidth - tooltipWidth - 10));
+                        }
+                        
+                        // Update nubbin class based on position
+                        me.nubbinClass = showOnRight ? 'slds-nubbin_left-top' : 'slds-nubbin_right-top';
+                        
+                        tipPosition = `top: ${top}px; left: ${left}px; visibility: visible`;
+                        tooltipDIV.setAttribute('style', tipPosition);
                     })
                     .on('mouseout', function () {
                         let tooltipDIV = me.template.querySelector('div.tooltip-panel');
@@ -1332,6 +1382,10 @@ export default class timeline extends NavigationMixin(LightningElement) {
             return true;
         }
         return false;
+    }
+
+    get tooltipClass() {
+        return `tooltip-panel tooltip-popover slds-popover_panel ${this.nubbinClass}`;
     }
 
     toggleFilter() {


### PR DESCRIPTION
I've updated the LTR positioning logic to:

First check if there's enough space on the right side
If yes, position on right and set hasEnoughSpace = true
If not enough space on right, check if there's enough space on left
If yes, position on left and set hasEnoughSpace = true

If not enough space on either side
Force position on right side without setting hasEnoughSpace
This means the tooltip will be allowed to extend beyond the viewport
The RTL logic remains unchanged, preferring the left side but falling back to right if needed.
The viewport boundary check (Math.max(10, Math.min(left, viewportWidth - tooltipWidth - 10))) will only be applied when 

hasEnoughSpace is true, which means:
For LTR: Only when there's enough space on the preferred side (right or left)
For RTL: Only when there's enough space on the left side

This should now handle all cases correctly:
LTR with enough space on right -> shows on right
LTR with not enough space on right but enough on left -> shows on left
LTR with not enough space on either side -> shows on right (may extend beyond viewport)
RTL with enough space on left -> shows on left
RTL with not enough space on left -> shows on right