### PR TITLE
fix: redraw the timeline when console panels resize the canvas

### DIFF
--- a/force-app/main/default/lwc/timeline/__tests__/timeline.test.js
+++ b/force-app/main/default/lwc/timeline/__tests__/timeline.test.js
@@ -156,6 +156,52 @@ describe('c-timeline', () => {
         expect(allTypesLabel.textContent).toBe('All Types');
     });
 
+    it('watches the canvas for size changes that never reach the window', async () => {
+        const observe = jest.fn();
+        const disconnect = jest.fn();
+        global.ResizeObserver = jest.fn(function () {
+            this.observe = observe;
+            this.disconnect = disconnect;
+        });
+
+        try {
+            const element = await buildTimeline();
+
+            expect(observe).toHaveBeenCalledWith(element.shadowRoot.querySelector('div.timeline-canvas'));
+
+            document.body.removeChild(element);
+            expect(disconnect).toHaveBeenCalled();
+        } finally {
+            delete global.ResizeObserver;
+        }
+    });
+
+    it('falls back to the window resize event when ResizeObserver is unavailable', async () => {
+        //jsdom has no ResizeObserver, which is also how Lightning Locker behaves
+        expect(typeof ResizeObserver).toBe('undefined');
+
+        const addEventListener = jest.spyOn(window, 'addEventListener');
+        const removeEventListener = jest.spyOn(window, 'removeEventListener');
+
+        const element = await buildTimeline();
+        expect(addEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
+
+        document.body.removeChild(element);
+        expect(removeEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
+    });
+
+    it('falls back to the window resize event when ResizeObserver cannot be constructed', async () => {
+        global.ResizeObserver = {};
+        const addEventListener = jest.spyOn(window, 'addEventListener');
+
+        try {
+            await buildTimeline();
+            expect(addEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
+        } finally {
+            delete global.ResizeObserver;
+        }
+    });
+
     it('toggles the filter panel and refresh button state', async () => {
         const element = await buildTimeline({ isLoaded: true });
         await flushPromises();

--- a/force-app/main/default/lwc/timeline/timeline.js
+++ b/force-app/main/default/lwc/timeline/timeline.js
@@ -186,7 +186,10 @@ export default class timeline extends NavigationMixin(LightningElement) {
     _d3timelineCanvasMapDIV = null;
 
     _d3Rendered = false;
+    _resizeObserver = null;
     _debouncedResizeHandler = null;
+    _resizeRafId = null;
+    _lastCanvasWidth = null;
     _tooltipDelayTimeout = null;
     _tooltipHideTimeout = null;
     _brushRafId = null;
@@ -336,10 +339,22 @@ export default class timeline extends NavigationMixin(LightningElement) {
             this._tooltipHideTimeout = null;
         }
 
+        if (this._resizeObserver) {
+            this._resizeObserver.disconnect();
+            this._resizeObserver = null;
+        }
+
         if (this._debouncedResizeHandler) {
             window.removeEventListener('resize', this._debouncedResizeHandler);
             this._debouncedResizeHandler = null;
         }
+
+        if (this._resizeRafId) {
+            cancelAnimationFrame(this._resizeRafId);
+            this._resizeRafId = null;
+        }
+
+        this._lastCanvasWidth = null;
     }
 
     connectedCallback() {
@@ -405,39 +420,82 @@ export default class timeline extends NavigationMixin(LightningElement) {
             }
         }
 
-        // In renderedCallback, after D3 setup
-        if (!this._debouncedResizeHandler) {
-            this._debouncedResizeHandler = this.debounce(() => {
-                try {
-                    const canvas = this.template.querySelector('div.timeline-canvas');
-                    // Ensure main D3 objects used in resize are initialized and canvas is valid
-                    if (
-                        canvas &&
-                        canvas.offsetWidth !== 0 &&
-                        this._d3timelineCanvas &&
-                        this._d3timelineMap &&
-                        this._d3timelineCanvasAxis &&
-                        this._d3timelineCanvasAxisLabel &&
-                        this._d3timelineMapAxis &&
-                        this._d3brush
-                    ) {
-                        this._d3timelineCanvas.x.range([0, canvas.offsetWidth]);
-                        this._d3timelineMap.x.range([
-                            0,
-                            Math.max(this.template.querySelector('div.timeline-map').offsetWidth, 0)
-                        ]);
-                        this._d3timelineCanvasAxis.redraw();
-                        this._d3timelineCanvasAxisLabel.redraw();
-                        this._d3timelineMap.redraw();
-                        this._d3timelineMapAxis.redraw();
-                        this._d3brush.redraw();
-                    }
-                    // eslint-disable-next-line
-                } catch (error) {
-                    // Intentionally swallowed — resize failures are non-critical
-                }
-            }, 200);
-            window.addEventListener('resize', this._debouncedResizeHandler);
+        this.observeCanvasWidth();
+    }
+
+    //Console apps slide docked panels and utility bars in and out without ever firing a window
+    //resize, so the canvas has to be watched directly rather than through a window listener.
+    observeCanvasWidth() {
+        if (this._resizeObserver || this._debouncedResizeHandler) {
+            return;
+        }
+
+        const canvas = this.template.querySelector('div.timeline-canvas');
+        if (!canvas) {
+            return;
+        }
+
+        //Measuring inside a ResizeObserver callback can trigger another notification, so the redraw
+        //is debounced and deferred to the next frame
+        const scheduleResize = this.debounce(() => {
+            // eslint-disable-next-line
+            this._resizeRafId = requestAnimationFrame(() => {
+                this._resizeRafId = null;
+                this.resizeTimeline();
+            });
+        }, 200);
+
+        //ResizeObserver is unavailable under Lightning Locker, where it is either missing outright
+        //or present but not constructible, so both are treated as a failure to attach
+        if (typeof ResizeObserver !== 'undefined') {
+            try {
+                this._resizeObserver = new ResizeObserver(scheduleResize);
+                this._resizeObserver.observe(canvas);
+                return;
+                // eslint-disable-next-line
+            } catch (error) {
+                this._resizeObserver = null;
+            }
+        }
+
+        //Locker fallback. This only catches window resizes, so panels sliding in and out of a
+        //console app are missed, but that is the pre-existing behaviour rather than a regression.
+        this._debouncedResizeHandler = scheduleResize;
+        window.addEventListener('resize', this._debouncedResizeHandler);
+    }
+
+    resizeTimeline() {
+        try {
+            const canvas = this.template.querySelector('div.timeline-canvas');
+            const canvasWidth = canvas ? canvas.offsetWidth : 0;
+
+            //A width of zero means the component is hidden, typically a background console tab.
+            //The last known width is kept so the timeline is left alone until it is visible again.
+            if (
+                canvasWidth === 0 ||
+                canvasWidth === this._lastCanvasWidth ||
+                !this._d3timelineCanvas ||
+                !this._d3timelineMap ||
+                !this._d3timelineCanvasAxis ||
+                !this._d3timelineCanvasAxisLabel ||
+                !this._d3timelineMapAxis ||
+                !this._d3brush
+            ) {
+                return;
+            }
+
+            this._lastCanvasWidth = canvasWidth;
+
+            this._d3timelineCanvas.x.range([0, canvasWidth]);
+            this._d3timelineMap.x.range([0, Math.max(this.template.querySelector('div.timeline-map').offsetWidth, 0)]);
+            this._d3timelineCanvasAxis.redraw();
+            this._d3timelineCanvasAxisLabel.redraw();
+            this._d3timelineMap.redraw();
+            this._d3timelineMapAxis.redraw();
+            this._d3brush.redraw();
+            // eslint-disable-next-line
+        } catch (error) {
+            // Intentionally swallowed — resize failures are non-critical
         }
     }
 
@@ -650,6 +708,10 @@ export default class timeline extends NavigationMixin(LightningElement) {
         const timelineHeight = me._timelineHeight;
 
         const width = timelineCanvasDIV.offsetWidth;
+
+        //Seeds the baseline the resize observer compares against so the first notification after
+        //the initial draw is not treated as a width change
+        me._lastCanvasWidth = width;
 
         timelineCanvasDIV.setAttribute('style', 'max-height:' + timelineHeight + 'px');
         timelineCanvas.SVGHeight = timelineHeight;


### PR DESCRIPTION
## Summary

Resizing the browser window redrew the timeline correctly, but Salesforce console apps slide docked panels and utility bars in and out without changing the viewport. No `resize` event fires, so the canvas kept rendering at its old width until something else forced a redraw.

The component now watches the canvas element with a `ResizeObserver` instead of listening on `window`, which catches any change to the drawing area regardless of what caused it — including plain window resizes, so it fully replaces the old listener.

- Redraws are debounced (200ms) and deferred to the next animation frame. The debounce absorbs the stream of intermediate sizes emitted while a panel animates, and the frame deferral avoids the "ResizeObserver loop completed with undelivered notifications" error that measuring inside the callback can trigger.
- A new `_lastCanvasWidth` field means height-only changes and duplicate notifications no longer cause pointless redraws. It is seeded during the initial draw in `timelineCanvas()`.
- A zero width means the component is hidden, which is what happens in a background console tab. Previously the timeline could stay stuck at a stale width after being hidden and re-shown; the observer now fires when it becomes visible again and the canvas re-fits.
- The observer is disconnected and any pending frame cancelled in `disconnectedCallback`, which matters in console apps where tabs are opened and closed constantly.

## Lightning Locker

`ResizeObserver` is not available under Lightning Locker, where it is either missing outright or reported as "not a constructor". Locker is still the default in orgs created before Winter '23 and has no announced retirement date, so attaching the observer is feature-detected *and* wrapped in `try`/`catch`, falling back to the previous `window` resize listener.

That fallback does not fix the panel case in Locker orgs, which is a deliberate trade-off: the alternative was polling the canvas width on an interval, which is not worth the ongoing cost for a legacy security architecture. Locker orgs keep exactly the behaviour they have today rather than regressing.

## Test plan

- [x] `npm test` — three new tests cover the observer being attached and disconnected, `ResizeObserver` missing, and `ResizeObserver` present but not constructible (the last two assert the window listener is added and removed)
- [x] `npx eslint` clean
- [x] Deployed to a scratch org (API 67, LWS enabled)
- [ ] In a console app, slide a docked panel or the utility bar in and out without resizing the window and confirm the timeline re-fits
- [ ] Switch to another console tab and back, and confirm the timeline re-fits after being hidden

Note: the jsdom test environment has no `ResizeObserver`, which mirrors Locker, so the observer test injects a mock.